### PR TITLE
fix: add pythonpath env var with root pointer to pm2 miner config

### DIFF
--- a/miner.config.js
+++ b/miner.config.js
@@ -3,7 +3,10 @@ module.exports = {
     {
       name: 'miner',
       script: 'python3',
-      args: './neurons/miner.py --netuid 247 --logging.debug --logging.trace --subtensor.network test --wallet.name miner --wallet.hotkey default --axon.port 8091'
+      args: './neurons/miner.py --netuid 247 --logging.debug --logging.trace --subtensor.network test --wallet.name miner --wallet.hotkey default --axon.port 8091',
+      env: {
+        PYTHONPATH: '.'
+      },
     },
   ],
 };


### PR DESCRIPTION
## Description

* Add `PYTHONPATH` env var to the pm2 miner app config to point to the root of the project to enable Python to locate the local Python modules.