### PR TITLE
Thykof/mod 1297 miners timeout issues

### DIFF
--- a/alembic/versions/a122779998c1_add_process_time_column_in_miner_.py
+++ b/alembic/versions/a122779998c1_add_process_time_column_in_miner_.py
@@ -1,0 +1,26 @@
+"""add process_time column in miner_predictions table
+
+Revision ID: a122779998c1
+Revises: a361b28ffa14
+Create Date: 2025-01-22 15:30:53.105524
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a122779998c1'
+down_revision: Union[str, None] = 'a361b28ffa14'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('miner_predictions', sa.Column('process_time', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('miner_predictions', 'process_time')

--- a/alembic/versions/a122779998c1_add_process_time_column_in_miner_.py
+++ b/alembic/versions/a122779998c1_add_process_time_column_in_miner_.py
@@ -5,6 +5,7 @@ Revises: a361b28ffa14
 Create Date: 2025-01-22 15:30:53.105524
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,15 +13,18 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'a122779998c1'
-down_revision: Union[str, None] = 'a361b28ffa14'
+revision: str = "a122779998c1"
+down_revision: Union[str, None] = "a361b28ffa14"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column('miner_predictions', sa.Column('process_time', sa.Float(), nullable=True))
+    op.add_column(
+        "miner_predictions",
+        sa.Column("process_time", sa.Float(), nullable=True),
+    )
 
 
 def downgrade() -> None:
-    op.drop_column('miner_predictions', 'process_time')
+    op.drop_column("miner_predictions", "process_time")

--- a/alembic/versions/a361b28ffa14_add_request_time_column_in_validator_.py
+++ b/alembic/versions/a361b28ffa14_add_request_time_column_in_validator_.py
@@ -1,0 +1,30 @@
+"""add request_time column in validator_requests table
+
+Revision ID: a361b28ffa14
+Revises: a8ca503ab8ec
+Create Date: 2025-01-22 14:49:20.011681
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a361b28ffa14"
+down_revision: Union[str, None] = "a8ca503ab8ec"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "validator_requests",
+        sa.Column("request_time", sa.TIMESTAMP(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("validator_requests", "request_time")

--- a/alembic/versions/a361b28ffa14_add_request_time_column_in_validator_.py
+++ b/alembic/versions/a361b28ffa14_add_request_time_column_in_validator_.py
@@ -22,7 +22,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column(
         "validator_requests",
-        sa.Column("request_time", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("request_time", sa.TIMESTAMP(timezone=True), nullable=True),
     )
 
 

--- a/simulation/db/models.py
+++ b/simulation/db/models.py
@@ -53,6 +53,7 @@ validator_requests = Table(
     Column("time_increment", Integer, nullable=True),
     Column("time_length", Integer, nullable=True),
     Column("num_simulations", Integer, nullable=True),
+    Column("request_time", DateTime(timezone=True), nullable=True),
 )
 
 # Define the table

--- a/simulation/db/models.py
+++ b/simulation/db/models.py
@@ -65,6 +65,7 @@ miner_predictions = Table(
     Column("miner_uid", Integer, nullable=False),
     Column("prediction", JSONB, nullable=False),
     Column("format_validation", String, nullable=True),
+    Column("process_time", Float, nullable=True),
 )
 
 # Define the table

--- a/simulation/utils/helpers.py
+++ b/simulation/utils/helpers.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timedelta, timezone
 
 
-def get_current_time():
+def get_current_time() -> datetime:
     # Get current date and time
-    current_time = datetime.now(timezone.utc).replace(microsecond=0)
-    return current_time.isoformat()
+    return datetime.now(timezone.utc).replace(microsecond=0)
 
 
 def convert_prices_to_time_format(prices, start_time, time_increment):
@@ -60,10 +59,7 @@ def get_intersecting_arrays(array1, array2):
     return filtered_array1, filtered_array2
 
 
-def round_time_to_minutes(dt_str, in_seconds, extra_seconds=0):
-    # Convert string to datetime object
-    dt = datetime.fromisoformat(dt_str)
-
+def round_time_to_minutes(dt: datetime, in_seconds: int, extra_seconds=0):
     # Define the rounding interval
     rounding_interval = timedelta(seconds=in_seconds)
 

--- a/simulation/utils/uids.py
+++ b/simulation/utils/uids.py
@@ -5,7 +5,7 @@ from typing import List
 
 
 def check_uid_availability(
-    metagraph: "bt.metagraph.Metagraph", uid: int, vpermit_tao_limit: int
+    metagraph: bt.metagraph, uid: int, vpermit_tao_limit: int
 ) -> bool:
     """Check if uid is available. The UID should be available if it is serving and has less than vpermit_tao_limit stake
     Args:

--- a/simulation/validator/forward.py
+++ b/simulation/validator/forward.py
@@ -97,7 +97,7 @@ async def forward(
         miner_data_handler=miner_data_handler,
         miner_uids=miner_uids,
         simulation_input=simulation_input,
-        current_time=current_time,
+        request_time=current_time,
     )
 
     # ================= Step 3 ================= #
@@ -242,7 +242,7 @@ async def _query_available_miners_and_save_responses(
     miner_data_handler: MinerDataHandler,
     miner_uids: list,
     simulation_input: SimulationInput,
-    current_time: datetime,
+    request_time: datetime,
 ):
     timeout = timeout_from_start_time(
         base_neuron.config.neuron.timeout, simulation_input.start_time
@@ -272,7 +272,7 @@ async def _query_available_miners_and_save_responses(
         response = synapse.deserialize()
         process_time = synapse.dendrite.process_time
         format_validation = validate_responses(
-            response, simulation_input, current_time, process_time
+            response, simulation_input, request_time, process_time
         )
         miner_id = miner_uids[i]
         miner_predictions[miner_id] = (
@@ -283,7 +283,7 @@ async def _query_available_miners_and_save_responses(
 
     if len(miner_predictions) > 0:
         miner_data_handler.save_responses(
-            miner_predictions, simulation_input, current_time
+            miner_predictions, simulation_input, request_time
         )
     else:
         bt.logging.info("skip saving because no prediction")

--- a/simulation/validator/forward.py
+++ b/simulation/validator/forward.py
@@ -97,6 +97,7 @@ async def forward(
         miner_data_handler=miner_data_handler,
         miner_uids=miner_uids,
         simulation_input=simulation_input,
+        current_time=current_time,
     )
 
     # ================= Step 3 ================= #
@@ -241,6 +242,7 @@ async def _query_available_miners_and_save_responses(
     miner_data_handler: MinerDataHandler,
     miner_uids: list,
     simulation_input: SimulationInput,
+    current_time: datetime,
 ):
     timeout = timeout_from_start_time(
         base_neuron.config.neuron.timeout, simulation_input.start_time
@@ -252,40 +254,45 @@ async def _query_available_miners_and_save_responses(
     synapse = Simulation(simulation_input=simulation_input)
     # The dendrite client queries the network:
     # it is the actual call to all the miners from validator
-    # returns an array of responses (predictions) for each of the miners
+    # returns an array of synapses (predictions) for each of the miners
     # ======================================================
     # miner has a unique uuid in the subnetwork
     # ======================================================
     # axon is a server application that accepts requests on the miner side
     # ======================================================
-    responses = await base_neuron.dendrite(
-        # Send the query to selected miner axons in the network.
+    synapses = await base_neuron.dendrite(
         axons=[base_neuron.metagraph.axons[uid] for uid in miner_uids],
-        # Construct a synapse object. This contains a simulation input parameters.
         synapse=synapse,
-        # All responses have the deserialize function called on them before returning.
-        # You are encouraged to define your own deserialization function.
-        # ======================================================
-        # we are using numpy for the outputs now - do we need to write a function that deserializes from json to numpy?
-        # you can find that function in "simulation.protocol.Simulation"
-        deserialize=True,
+        deserialize=False,
         timeout=timeout,
     )
 
     miner_predictions = {}
-    for i, response in enumerate(responses):
-        format_validation = validate_responses(response, simulation_input)
+    for i, synapse in enumerate(synapses):
+        response = synapse.deserialize()
+        process_time = synapse.dendrite.process_time
+        format_validation = validate_responses(
+            response, simulation_input, current_time, process_time
+        )
         miner_id = miner_uids[i]
-        miner_predictions[miner_id] = (response, format_validation)
+        miner_predictions[miner_id] = (
+            response,
+            format_validation,
+            process_time,
+        )
 
     if len(miner_predictions) > 0:
-        miner_data_handler.save_responses(miner_predictions, simulation_input)
+        miner_data_handler.save_responses(
+            miner_predictions, simulation_input, current_time
+        )
     else:
         bt.logging.info("skip saving because no prediction")
 
 
 def _get_available_miners_and_update_metagraph_history(
-    base_neuron, miner_data_handler: MinerDataHandler, start_time
+    base_neuron: BaseValidatorNeuron,
+    miner_data_handler: MinerDataHandler,
+    start_time: str,
 ):
     miner_uids = []
     metagraph_info = []

--- a/simulation/validator/miner_data_handler.py
+++ b/simulation/validator/miner_data_handler.py
@@ -25,7 +25,7 @@ class MinerDataHandler:
         self,
         miner_predictions: dict[tuple],
         simulation_input: SimulationInput,
-        current_time: datetime,
+        request_time: datetime,
     ):
         """Save miner predictions and simulation input."""
 
@@ -35,7 +35,7 @@ class MinerDataHandler:
             "time_increment": simulation_input.time_increment,
             "time_length": simulation_input.time_length,
             "num_simulations": simulation_input.num_simulations,
-            "request_time": current_time.isoformat(),
+            "request_time": request_time.isoformat(),
         }
 
         try:
@@ -55,7 +55,6 @@ class MinerDataHandler:
                         format_validation,
                         process_time,
                     ) in miner_predictions.items():
-                        print("process time", process_time)  # DEBUG
                         # If the format is not correct, we don't save the prediction
                         if format_validation != response_validation.CORRECT:
                             prediction = []
@@ -66,7 +65,7 @@ class MinerDataHandler:
                                 "miner_uid": miner_uid,
                                 "prediction": prediction,
                                 "format_validation": format_validation,
-                                # "process_time": process_time,
+                                "process_time": process_time,
                             }
                         )
 

--- a/simulation/validator/miner_data_handler.py
+++ b/simulation/validator/miner_data_handler.py
@@ -22,7 +22,10 @@ class MinerDataHandler:
         self.engine = engine or get_engine()
 
     def save_responses(
-        self, miner_predictions: dict, simulation_input: SimulationInput
+        self,
+        miner_predictions: dict[tuple],
+        simulation_input: SimulationInput,
+        current_time: datetime,
     ):
         """Save miner predictions and simulation input."""
 
@@ -32,6 +35,7 @@ class MinerDataHandler:
             "time_increment": simulation_input.time_increment,
             "time_length": simulation_input.time_length,
             "num_simulations": simulation_input.num_simulations,
+            "request_time": current_time.isoformat(),
         }
 
         try:
@@ -49,7 +53,9 @@ class MinerDataHandler:
                     for miner_uid, (
                         prediction,
                         format_validation,
+                        process_time,
                     ) in miner_predictions.items():
+                        print("process time", process_time)  # DEBUG
                         # If the format is not correct, we don't save the prediction
                         if format_validation != response_validation.CORRECT:
                             prediction = []
@@ -60,6 +66,7 @@ class MinerDataHandler:
                                 "miner_uid": miner_uid,
                                 "prediction": prediction,
                                 "format_validation": format_validation,
+                                # "process_time": process_time,
                             }
                         )
 
@@ -217,7 +224,7 @@ class MinerDataHandler:
             bt.logging.error(f"in get_miner_scores (got an exception): {e}")
             return pd.DataFrame()
 
-    def update_miner_rewards(self, miner_rewards_data: []):
+    def update_miner_rewards(self, miner_rewards_data: list[dict]):
         try:
             with self.engine.connect() as connection:
                 with connection.begin():  # Begin a transaction

--- a/simulation/validator/moving_average.py
+++ b/simulation/validator/moving_average.py
@@ -9,7 +9,7 @@ def compute_weighted_averages(
     half_life_days: float,
     alpha: float,
     validation_time_str: str,
-) -> []:
+) -> list[dict]:
     """
     Reads a TSV file of miner rewards, computes an exponentially weighted
     moving average (EWMA) with a user-specified half-life, then outputs:

--- a/simulation/validator/response_validation.py
+++ b/simulation/validator/response_validation.py
@@ -23,7 +23,7 @@ def validate_responses(
     # check the process time
     if process_time_str is None:
         return "time out (process time is None)"
-    
+
     received_at = request_time + timedelta(seconds=float(process_time_str))
     start_time = datetime.fromisoformat(simulation_input.start_time)
     if received_at > start_time:

--- a/simulation/validator/response_validation.py
+++ b/simulation/validator/response_validation.py
@@ -22,7 +22,7 @@ def validate_responses(
     """
     # check the process time
     if process_time_str is None:
-        return "time out (process time is None)"
+        return "time out or internal server error (process time is None)"
 
     received_at = request_time + timedelta(seconds=float(process_time_str))
     start_time = datetime.fromisoformat(simulation_input.start_time)

--- a/simulation/validator/response_validation.py
+++ b/simulation/validator/response_validation.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import typing
 
 
 from simulation.simulation_input import SimulationInput
@@ -9,8 +10,8 @@ CORRECT = "CORRECT"
 def validate_responses(
     response,
     simulation_input: SimulationInput,
-    current_time: datetime,
-    process_time: str,
+    request_time: datetime,
+    process_time_str: typing.Optional[str],
 ) -> str:
     """
     Validate responses from miners.
@@ -20,8 +21,13 @@ def validate_responses(
     otherwise, return "CORRECT".
     """
     # check the process time
-    print(f"Process time: {process_time}")
-    print(f"Current time: {current_time}")
+    if process_time_str is None:
+        return "time out (process time is None)"
+    
+    received_at = request_time + timedelta(seconds=float(process_time_str))
+    start_time = datetime.fromisoformat(simulation_input.start_time)
+    if received_at > start_time:
+        return f"Response received after the simulation start time: expected {start_time}, got {received_at}"
 
     # check if the response is empty
     if response is None or len(response) == 0:

--- a/simulation/validator/response_validation.py
+++ b/simulation/validator/response_validation.py
@@ -6,12 +6,24 @@ from simulation.simulation_input import SimulationInput
 CORRECT = "CORRECT"
 
 
-def validate_responses(response, simulation_input: SimulationInput) -> str:
+def validate_responses(
+    response,
+    simulation_input: SimulationInput,
+    current_time: datetime,
+    process_time: str,
+) -> str:
     """
     Validate responses from miners.
 
-    Return False if response is incorrect.
+    Return a string with the error message
+    if the response is not following the expected format or the response is empty,
+    otherwise, return "CORRECT".
     """
+    # check the process time
+    print(f"Process time: {process_time}")
+    print(f"Current time: {current_time}")
+
+    # check if the response is empty
     if response is None or len(response) == 0:
         return "Response is empty"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 
 from simulation.utils.helpers import (
     convert_prices_to_time_format,
@@ -80,8 +81,12 @@ class TestHelpers(unittest.TestCase):
         dt_str_1 = "2024-11-25T19:01:59.940515"
         dt_str_2 = "2024-11-25T19:03:59.940515"
 
-        result_1 = round_time_to_minutes(dt_str_1, time_increment)
-        result_2 = round_time_to_minutes(dt_str_2, time_increment)
+        result_1 = round_time_to_minutes(
+            datetime.fromisoformat(dt_str_1), time_increment
+        )
+        result_2 = round_time_to_minutes(
+            datetime.fromisoformat(dt_str_2), time_increment
+        )
 
         self.assertEqual(result_1, "2024-11-25T19:05:00")
         self.assertEqual(result_2, "2024-11-25T19:05:00")
@@ -94,10 +99,10 @@ class TestHelpers(unittest.TestCase):
         dt_str_2 = "2024-11-25T19:03:59.940515"
 
         result_1 = round_time_to_minutes(
-            dt_str_1, time_increment, extra_seconds
+            datetime.fromisoformat(dt_str_1), time_increment, extra_seconds
         )
         result_2 = round_time_to_minutes(
-            dt_str_2, time_increment, extra_seconds
+            datetime.fromisoformat(dt_str_2), time_increment, extra_seconds
         )
 
         self.assertEqual(result_1, "2024-11-25T19:03:00")

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -40,9 +40,9 @@ def test_get_values_within_range(db_engine):
     )
 
     values = generate_values(datetime.fromisoformat(start_time))
-    simulation_data = {miner_id: (values, response_validation.CORRECT)}
+    simulation_data = {miner_id: (values, response_validation.CORRECT, "12")}
     handler = MinerDataHandler(db_engine)
-    handler.save_responses(simulation_data, simulation_input)
+    handler.save_responses(simulation_data, simulation_input, datetime.now())
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input
@@ -84,9 +84,9 @@ def test_get_values_ongoing_range(db_engine):
     )
 
     values = generate_values(datetime.fromisoformat(start_time))
-    simulation_data = {miner_id: (values, response_validation.CORRECT)}
+    simulation_data = {miner_id: (values, response_validation.CORRECT, "12")}
     handler = MinerDataHandler(db_engine)
-    handler.save_responses(simulation_data, simulation_input)
+    handler.save_responses(simulation_data, simulation_input, datetime.now())
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input
@@ -138,12 +138,20 @@ def test_multiple_records_for_same_miner(db_engine):
     handler = MinerDataHandler(db_engine)
 
     values_1 = generate_values(datetime.fromisoformat(start_time_1))
-    simulation_data_1 = {miner_id: (values_1, response_validation.CORRECT)}
-    handler.save_responses(simulation_data_1, simulation_input_1)
+    simulation_data_1 = {
+        miner_id: (values_1, response_validation.CORRECT, "12")
+    }
+    handler.save_responses(
+        simulation_data_1, simulation_input_1, datetime.now()
+    )
 
     values_2 = generate_values(datetime.fromisoformat(start_time_2))
-    simulation_data_2 = {miner_id: (values_2, response_validation.CORRECT)}
-    handler.save_responses(simulation_data_2, simulation_input_2)
+    simulation_data_2 = {
+        miner_id: (values_2, response_validation.CORRECT, "12")
+    }
+    handler.save_responses(
+        simulation_data_2, simulation_input_2, datetime.now()
+    )
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input_1
@@ -204,12 +212,20 @@ def test_multiple_records_for_same_miner_with_overlapping(db_engine):
     handler = MinerDataHandler(db_engine)
 
     values_1 = generate_values(datetime.fromisoformat(start_time_1))
-    simulation_data_1 = {miner_id: (values_1, response_validation.CORRECT)}
-    handler.save_responses(simulation_data_1, simulation_input_1)
+    simulation_data_1 = {
+        miner_id: (values_1, response_validation.CORRECT, "12")
+    }
+    handler.save_responses(
+        simulation_data_1, simulation_input_1, datetime.now()
+    )
 
     values_2 = generate_values(datetime.fromisoformat(start_time_2))
-    simulation_data_2 = {miner_id: (values_2, response_validation.CORRECT)}
-    handler.save_responses(simulation_data_2, simulation_input_2)
+    simulation_data_2 = {
+        miner_id: (values_2, response_validation.CORRECT, "12")
+    }
+    handler.save_responses(
+        simulation_data_2, simulation_input_2, datetime.now()
+    )
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input_1
@@ -273,9 +289,9 @@ def test_get_values_incorrect_format(db_engine):
     )
 
     error_string = "some errors in the format"
-    simulation_data = {miner_id: ([], error_string)}
+    simulation_data = {miner_id: ([], error_string, "12")}
     handler = MinerDataHandler(db_engine)
-    handler.save_responses(simulation_data, simulation_input)
+    handler.save_responses(simulation_data, simulation_input, datetime.now())
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -108,7 +108,7 @@ def test_get_rewards(db_engine):
 
     values = generate_values(datetime.fromisoformat(start_time))
     simulation_data = {miner_id: (values, response_validation.CORRECT)}
-    handler.save_responses(simulation_data, simulation_input)
+    handler.save_responses(simulation_data, simulation_input, datetime.now())
 
     validator_request_id = handler.get_latest_prediction_request(
         scored_time, simulation_input

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -107,7 +107,7 @@ def test_get_rewards(db_engine):
     )  # TODO: add a mock instead of the real provider
 
     values = generate_values(datetime.fromisoformat(start_time))
-    simulation_data = {miner_id: (values, response_validation.CORRECT)}
+    simulation_data = {miner_id: (values, response_validation.CORRECT, "1.2")}
     handler.save_responses(simulation_data, simulation_input, datetime.now())
 
     validator_request_id = handler.get_latest_prediction_request(


### PR DESCRIPTION
in this PR, 
- we store in the validator_requests table the request_time,
- and we store the process_time in seconds in the miner_predictions table
- we also validate that the (process_time + request_time) is lower that simulation start time
  - but in fact it's not possible if we don't use the neuron.config option because the dynamic timeout will trigger and prevent any response 
