### PR TITLE
Whitelist validators

### DIFF
--- a/docs/miner_guide.md
+++ b/docs/miner_guide.md
@@ -234,6 +234,38 @@ pm2 start miner.config.js -- --blacklist.validator_min_stake 1000
 
 <sup>[Back to top ^][table-of-contents]</sup>
 
+#### `--blacklist.validator_exceptions INTEGER INTEGER INTEGER ...`
+
+List of validator exceptions (e.g., --blacklist.validator_exceptions 0 1 17 34 49).
+
+Default: `[]`
+
+Example:
+
+```js
+// miner.config.js
+module.exports = {
+  apps: [
+    {
+      name: 'miner',
+      interpreter: 'python3',
+      script: './neurons/miner.py',
+      args: '--blacklist.validator_exceptions 0 1 17 34 49',
+      env: {
+        PYTHONPATH: '.'
+      },
+    },
+  ],
+};
+```
+
+Alternatively, you can add the args directly to the command:
+```shell
+pm2 start miner.config.js -- --blacklist.validator_exceptions 0 1 17 34 49
+```
+
+<sup>[Back to top ^][table-of-contents]</sup>
+
 #### `--logging.debug`
 
 Turn on bittensor debugging information.

--- a/miner.config.js
+++ b/miner.config.js
@@ -4,7 +4,7 @@ module.exports = {
       name: 'miner',
       interpreter: 'python3',
       script: './neurons/miner.py',
-      args: '--netuid 50 --logging.debug --logging.trace --wallet.name miner --wallet.hotkey default --axon.port 8091 --blacklist.force_validator_permit true --blacklist.validator_min_stake 1000 --blacklist.validator_exceptions 0 1 17 34 49',
+      args: '--netuid 50 --logging.debug --logging.trace --wallet.name miner --wallet.hotkey default --axon.port 8091 --blacklist.force_validator_permit true --blacklist.validator_min_stake 1000 --blacklist.validator_exceptions 0 1 8 17 34 49 53 114 131',
       env: {
         PYTHONPATH: '.'
       },

--- a/miner.config.js
+++ b/miner.config.js
@@ -4,7 +4,7 @@ module.exports = {
       name: 'miner',
       interpreter: 'python3',
       script: './neurons/miner.py',
-      args: '--netuid 50 --logging.debug --logging.trace --wallet.name miner --wallet.hotkey default --axon.port 8091 --blacklist.force_validator_permit true --blacklist.validator_min_stake 1000',
+      args: '--netuid 50 --logging.debug --logging.trace --wallet.name miner --wallet.hotkey default --axon.port 8091 --blacklist.force_validator_permit true --blacklist.validator_min_stake 1000 --blacklist.validator_exceptions 0 1 17 34 49',
       env: {
         PYTHONPATH: '.'
       },

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -132,8 +132,9 @@ class Miner(BaseMinerNeuron):
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
         stake = self.metagraph.S[uid]
         bt.logging.info(f"Requesting UID: {uid} | Stake at UID: {stake}")
+        bt.logging.info(f"Whitelisted validators: {self.config.blacklist.validator_exceptions}")
 
-        if stake <= self.config.blacklist.validator_min_stake:
+        if uid not in self.config.blacklist.validator_exceptions and stake <= self.config.blacklist.validator_min_stake:
             # Ignore requests if the stake is below minimum
             bt.logging.info(
                 f"Hotkey: {synapse.dendrite.hotkey}: stake below minimum threshold of {self.config.blacklist.validator_min_stake}"

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -132,10 +132,14 @@ class Miner(BaseMinerNeuron):
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
         stake = self.metagraph.S[uid]
         bt.logging.info(f"Requesting UID: {uid} | Stake at UID: {stake}")
-        bt.logging.info(f"Whitelisted validators: {self.config.blacklist.validator_exceptions}")
+        bt.logging.info(
+            f"Whitelisted validators: {self.config.blacklist.validator_exceptions}"
+        )
 
         if uid in self.config.blacklist.validator_exceptions:
-            bt.logging.info(f"Requesting UID: {uid} whitelisted as a validator")
+            bt.logging.info(
+                f"Requesting UID: {uid} whitelisted as a validator"
+            )
         else:
             if stake <= self.config.blacklist.validator_min_stake:
                 # Ignore requests if the stake is below minimum

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -134,12 +134,15 @@ class Miner(BaseMinerNeuron):
         bt.logging.info(f"Requesting UID: {uid} | Stake at UID: {stake}")
         bt.logging.info(f"Whitelisted validators: {self.config.blacklist.validator_exceptions}")
 
-        if uid not in self.config.blacklist.validator_exceptions and stake <= self.config.blacklist.validator_min_stake:
-            # Ignore requests if the stake is below minimum
-            bt.logging.info(
-                f"Hotkey: {synapse.dendrite.hotkey}: stake below minimum threshold of {self.config.blacklist.validator_min_stake}"
-            )
-            return True, "Stake below minimum threshold"
+        if uid in self.config.blacklist.validator_exceptions:
+            bt.logging.info(f"Requesting UID: {uid} whitelisted as a validator")
+        else:
+            if stake <= self.config.blacklist.validator_min_stake:
+                # Ignore requests if the stake is below minimum
+                bt.logging.info(
+                    f"Hotkey: {synapse.dendrite.hotkey}: stake below minimum threshold of {self.config.blacklist.validator_min_stake}"
+                )
+                return True, "Stake below minimum threshold"
 
         if self.config.blacklist.force_validator_permit:
             # If the config is set to force validator permit, then we should only allow requests from validators.

--- a/synth/utils/config.py
+++ b/synth/utils/config.py
@@ -163,6 +163,14 @@ def add_miner_args(cls, parser):
     )
 
     parser.add_argument(
+        "--blacklist.validator_exceptions",
+        type=int,
+        nargs="+",
+        default=[],
+        help="List of validator exceptions (e.g., --blacklist.validator_exceptions 1 3 10)",
+    )
+
+    parser.add_argument(
         "--wandb.project_name",
         type=str,
         default="template-miners",


### PR DESCRIPTION
Several miners report issues with checking stake for validators:
- for some reason metagraph returns incorrect values of stake amount for validators

Workaround solution:
- miners can add a validator to a whitelist, so no need to check the stake amount