### PR TITLE
Rework auto restart

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -102,7 +102,4 @@ class Validator(BaseValidatorNeuron):
 
 # The main function parses the configuration and runs the validator.
 if __name__ == "__main__":
-    with Validator() as validator:
-        while not validator.should_exit:
-            bt.logging.info(f"Validator running... {time.time()}")
-            time.sleep(600)
+    Validator().run()

--- a/synth/base/validator.py
+++ b/synth/base/validator.py
@@ -164,8 +164,6 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.debug(
                 str(print_exception(type(err), err, err.__traceback__))
             )
-            bt.logging.debug("Scheduling validator to stop.")
-            self.should_exit = True
 
     def run_in_background_thread(self):
         """

--- a/synth/base/validator.py
+++ b/synth/base/validator.py
@@ -138,8 +138,6 @@ class BaseValidatorNeuron(BaseNeuron):
         # This loop maintains the validator's operations until intentionally stopped.
         try:
             while True:
-                bt.logging.info(f"step({self.step}) block({self.block})")
-
                 # Run multiple forwards concurrently.
                 self.loop.run_until_complete(self.concurrent_forward())
 


### PR DESCRIPTION
It can happen that:
- error occur while validating
- the exception is catch, the validator is scheduled to stop
- but the stop happen at worst 10 minutes after