### PR TITLE
Enforce absolute validator cutoff at simulation start_time

### DIFF
--- a/synth/base/dendrite_multiprocess.py
+++ b/synth/base/dendrite_multiprocess.py
@@ -2,6 +2,7 @@ import sys
 import threading
 import logging.handlers
 import time
+from datetime import datetime, timezone
 from typing import Union
 import asyncio
 import concurrent.futures
@@ -161,6 +162,7 @@ async def call(
     timeout: float,
 ):
     start_time = time.time()
+    received_at = None
     target_axon = (
         target_axon.info() if isinstance(target_axon, bt.Axon) else target_axon
     )
@@ -192,6 +194,7 @@ async def call(
             headers=synapse.to_headers(),
             json=synapse_body,
         )
+        received_at = datetime.now(timezone.utc).isoformat()
         response.raise_for_status()
         json_response = response.json()
         process_server_response(
@@ -208,7 +211,11 @@ async def call(
             f"dendrite | <-- | {synapse.get_total_size()} B | {synapse.name} | {synapse.axon.hotkey} | {synapse.axon.ip}:{str(synapse.axon.port)} | {synapse.dendrite.status_code} | {synapse.dendrite.status_message}"
         )
 
-        return [synapse.simulation_output, synapse.dendrite.process_time]
+        return [
+            synapse.simulation_output,
+            synapse.dendrite.process_time,
+            received_at,
+        ]
 
 
 async def worker(
@@ -320,7 +327,7 @@ def sync_forward_multiprocess(
     synapse: Simulation,
     timeout: float,
     nprocs: int = 2,
-) -> list[Simulation]:
+) -> list[tuple[Simulation, str | None, str | None]]:
     bt.logging.debug(
         f"Starting multiprocess forward with {nprocs} processes.", "dendrite"
     )
@@ -348,13 +355,15 @@ def sync_forward_multiprocess(
             repeat(timeout),
         )
         for chunk_results in intermediate_results:
-            for simulation_output, process_time in chunk_results:
+            for simulation_output, process_time, received_at in chunk_results:
                 synapse_result = Simulation(
                     simulation_input=SimulationInput()
                 ).from_headers(synapse.to_headers())
                 synapse_result.simulation_output = simulation_output
                 synapse_result.dendrite.process_time = process_time
-                results.append(synapse_result.model_copy())
+                results.append(
+                    (synapse_result.model_copy(), process_time, received_at)
+                )
 
     return results
 

--- a/synth/utils/helpers.py
+++ b/synth/utils/helpers.py
@@ -117,7 +117,9 @@ def from_iso_to_unix_time(iso_time: str):
     return int(dt.timestamp())
 
 
-def timeout_from_start_time(start_time_str: str) -> float:
+def timeout_from_start_time(
+    start_time_str: str, max_timeout: float | None = None
+) -> float:
     """
     Calculate the timeout duration from the start_time to the current time.
 
@@ -126,12 +128,20 @@ def timeout_from_start_time(start_time_str: str) -> float:
     """
     # Convert start_time to a datetime object
     start_time = datetime.fromisoformat(start_time_str)
+    if start_time.tzinfo is None:
+        start_time = start_time.replace(tzinfo=timezone.utc)
+    else:
+        start_time = start_time.astimezone(timezone.utc)
 
     # Get current date and time
     current_time = datetime.now(timezone.utc)
 
     # Calculate the timeout duration
-    return (start_time - current_time).total_seconds()
+    timeout = (start_time - current_time).total_seconds()
+    if max_timeout is not None:
+        timeout = min(timeout, max_timeout)
+
+    return timeout
 
 
 def convert_list_elements_to_str(items: list[int]) -> list[str]:

--- a/synth/validator/forward.py
+++ b/synth/validator/forward.py
@@ -185,7 +185,15 @@ def query_available_miners_and_save_responses(
     simulation_input: SimulationInput,
     request_time: datetime,
 ):
-    timeout = timeout_from_start_time(simulation_input.start_time)
+    timeout = timeout_from_start_time(
+        simulation_input.start_time, base_neuron.config.neuron.timeout
+    )
+    if timeout <= 0:
+        bt.logging.warning(
+            f"Skipping expired prompt for {simulation_input.asset} "
+            f"(start_time={simulation_input.start_time}, timeout={timeout})"
+        )
+        return
 
     # synapse - is a message that validator sends to miner to get results, i.e. simulation_input in our case
     # Simulation - is our protocol, i.e. input and output message of a miner (application that returns prediction of
@@ -228,12 +236,14 @@ def query_available_miners_and_save_responses(
     )
 
     miner_predictions = {}
-    for i, synapse in enumerate(synapses):
+    for i, (synapse, process_time, received_at) in enumerate(synapses):
         response = synapse.deserialize()
-        process_time = synapse.dendrite.process_time
         try:
             format_validation = validate_responses_v2(
-                response, simulation_input, process_time
+                response,
+                simulation_input,
+                process_time,
+                received_at,
             )
         except Exception:
             format_validation = "error during validation"

--- a/synth/validator/response_validation_v2.py
+++ b/synth/validator/response_validation_v2.py
@@ -1,10 +1,17 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import typing
 
 
 from synth.simulation_input import SimulationInput
 
 CORRECT = "CORRECT"
+
+
+def normalize_to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+
+    return dt.astimezone(timezone.utc)
 
 
 def validate_path(
@@ -52,6 +59,7 @@ def validate_responses(
     response,
     simulation_input: SimulationInput,
     process_time_str: typing.Optional[str],
+    received_at_str: typing.Optional[str] = None,
 ) -> str:
     """
     Validate responses from miners.
@@ -64,7 +72,18 @@ def validate_responses(
     if process_time_str is None:
         return "time out or internal server error (process time is None)"
 
-    start_time = datetime.fromisoformat(simulation_input.start_time)
+    start_time = normalize_to_utc(
+        datetime.fromisoformat(simulation_input.start_time)
+    )
+
+    if received_at_str is not None:
+        received_at = normalize_to_utc(datetime.fromisoformat(received_at_str))
+        if received_at > start_time:
+            return (
+                "Response arrived after start_time: "
+                f"received_at={received_at.isoformat()}, "
+                f"start_time={start_time.isoformat()}"
+            )
 
     error_message = validate_response_type(response)
     if error_message:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 
 from synth.utils.helpers import (
@@ -9,6 +9,7 @@ from synth.utils.helpers import (
     from_iso_to_unix_time,
     get_current_time,
     round_to_8_significant_digits,
+    timeout_from_start_time,
 )
 
 
@@ -139,3 +140,23 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(
             from_iso_to_unix_time("2025-08-05T14:56:00+00:00"), 1754405760
         )
+
+    def test_timeout_from_start_time_caps_to_configured_timeout(self):
+        start_time = (
+            datetime.now(timezone.utc) + timedelta(seconds=120)
+        ).isoformat()
+
+        timeout = timeout_from_start_time(start_time, max_timeout=30)
+
+        self.assertLessEqual(timeout, 30)
+        self.assertGreater(timeout, 0)
+
+    def test_timeout_from_start_time_does_not_widen_timeout(self):
+        start_time = (
+            datetime.now(timezone.utc) + timedelta(seconds=45)
+        ).isoformat()
+
+        timeout = timeout_from_start_time(start_time, max_timeout=120)
+
+        self.assertLessEqual(timeout, 45)
+        self.assertGreater(timeout, 0)

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -252,3 +252,75 @@ def test_validate_responses_correct_2():
 
     result = validate_responses(response, simulation_input, process_time_str)
     assert result == CORRECT
+
+
+def test_validate_responses_before_cutoff():
+    simulation_input = SimulationInput(
+        start_time=start_time.isoformat(),
+        num_simulations=1,
+        time_length=3,
+        time_increment=time_increment,
+    )
+    response = [
+        int(start_time.timestamp()),
+        time_increment,
+        [123.45678] * 4,
+    ]
+
+    result = validate_responses(
+        response,
+        simulation_input,
+        "0",
+        datetime.fromisoformat("2022-12-31T23:59:59+00:00").isoformat(),
+    )
+
+    assert result == CORRECT
+
+
+def test_validate_responses_after_cutoff():
+    simulation_input = SimulationInput(
+        start_time=start_time.isoformat(),
+        num_simulations=1,
+        time_length=3,
+        time_increment=time_increment,
+    )
+    response = [
+        int(start_time.timestamp()),
+        time_increment,
+        [123.45678] * 4,
+    ]
+
+    result = validate_responses(
+        response,
+        simulation_input,
+        "0",
+        datetime.fromisoformat("2023-01-01T00:00:01+00:00").isoformat(),
+    )
+
+    assert (
+        result
+        == "Response arrived after start_time: received_at=2023-01-01T00:00:01+00:00, start_time=2023-01-01T00:00:00+00:00"
+    )
+
+
+def test_validate_responses_at_cutoff_boundary():
+    simulation_input = SimulationInput(
+        start_time=start_time.isoformat(),
+        num_simulations=1,
+        time_length=3,
+        time_increment=time_increment,
+    )
+    response = [
+        int(start_time.timestamp()),
+        time_increment,
+        [123.45678] * 4,
+    ]
+
+    result = validate_responses(
+        response,
+        simulation_input,
+        "0",
+        start_time.isoformat(),
+    )
+
+    assert result == CORRECT


### PR DESCRIPTION
## Background
The validator currently derives a relative transport timeout from `simulation_input.start_time` and uses that timeout when querying miners. In practice, that means acceptance is driven by whether a response arrives before the relative client timeout expires, not by whether the validator actually received the response before the protocol deadline.

## Issue
This creates a fairness problem because slightly late responses can still be accepted when they land inside transport slack. A miner with low-latency infrastructure can wait longer, anchor closer to `t0`, and still pass validation even though the response arrived after `start_time`. That extra anchoring time is a real security and fairness concern because it rewards timing advantage rather than better modeling.

## Root cause
The implementation enforced a relative timeout but did not enforce a validator-side absolute receive cutoff at `simulation_input.start_time`. The response validation path checked structure and `process_time`, but it did not compare an actual validator receipt timestamp against the declared deadline.

## Fix
This PR records `received_at` as close as possible to validator-side receipt in the active multiprocess dendrite path, threads that timestamp through the validator response flow, normalizes the comparison explicitly in UTC, and rejects responses where `received_at > start_time`.

It also makes the existing `--neuron.timeout` setting act as a cap on the query timeout when configured, without widening the current timing window. This approach was chosen because it enforces the intended protocol deadline with a minimal patch and without changing scoring or payload structure.

After this patch, a response must both arrive before the transport timeout and be received by the validator no later than `simulation_input.start_time` to be accepted. Responses received exactly at the cutoff remain valid.

## Impact
This closes the highest-priority timing-based fairness gap found in the audit. Miners no longer get extra acceptance slack past `start_time`, so low-latency operators have less ability to anchor on fresher prices simply by replying later. The change improves deadline enforcement without changing scoring math or reward transforms.

## Scope / non-goals
This PR fixes absolute deadline enforcement for miner responses.

It intentionally does not:
- change scoring math or CRPS behavior
- change prompt generation cadence
- randomize asset scheduling
- address other protocol or leaderboard issues outside cutoff enforcement

## Risk / compatibility
This changes protocol behavior only in the sense that the validator now enforces the deadline the protocol already implies. Maintainers may want to review the exact receipt-time capture point, but this uses the closest practical validator-side receipt point in the current architecture without a larger transport refactor.

## Testing
Tests run:
- `python -m pytest --noconftest tests/test_response_validation.py tests/test_helpers.py -q`
- `python -m py_compile synth/utils/helpers.py synth/validator/response_validation_v2.py synth/base/dendrite_multiprocess.py synth/validator/forward.py tests/test_response_validation.py tests/test_helpers.py`

New coverage added:
- valid structured response before cutoff is accepted
- response received after cutoff is rejected
- response received exactly at cutoff remains valid
- configured timeout caps are honored without widening the effective timeout window

Expected behavior before this patch:
- structurally valid responses could still be accepted slightly after `start_time` if they arrived within relative transport slack

Expected behavior after this patch:
- structurally valid responses are rejected once the validator-side receive timestamp is later than `start_time`

Reviewer note: This is a focused fairness fix and intentionally avoids unrelated scoring/protocol changes.
