### PR TITLE
Randomize per-cycle asset order to reduce miner predictability

### DIFF
--- a/synth/utils/sequential_scheduler.py
+++ b/synth/utils/sequential_scheduler.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta, timezone
+import hashlib
+import os
+import secrets
 import time
 
 
@@ -21,6 +24,9 @@ class SequentialScheduler:
         self.target = target
         self.miner_data_handler = miner_data_handler
         self.first_run = True
+        self.schedule_secret = (
+            os.getenv("VALIDATOR_SCHEDULE_SECRET") or secrets.token_hex(32)
+        )
 
     def start(self):
         cycle_start_time = get_current_time()
@@ -47,16 +53,20 @@ class SequentialScheduler:
             elif prompt_config.label == "high":
                 asset_list = prompt_config.asset_list[:4]
 
-        delay = self.select_delay(
+        next_run_time = self.select_next_run_time(
             asset_list,
             cycle_start_time,
             prompt_config,
             self.first_run,
         )
-        latest_asset = self.miner_data_handler.get_latest_asset(
-            prompt_config.time_length
+        delay = self.select_delay(next_run_time)
+        asset_order = self.shuffle_assets_for_cycle(
+            asset_list,
+            next_run_time,
+            prompt_config,
+            self.schedule_secret,
         )
-        asset = self.select_asset(latest_asset, asset_list)
+        asset = self.select_asset(next_run_time, asset_order, prompt_config)
 
         bt.logging.info(
             f"Scheduling next {prompt_config.label} frequency cycle for asset {asset} in {delay} seconds"
@@ -69,12 +79,12 @@ class SequentialScheduler:
         return cycle_start_time
 
     @staticmethod
-    def select_delay(
+    def select_next_run_time(
         asset_list: list[str],
         cycle_start_time: datetime,
         prompt_config: PromptConfig,
         first_run: bool = False,
-    ) -> int:
+    ) -> datetime:
         next_cycle = cycle_start_time
         next_cycle = round_time_to_minutes(next_cycle)
         if not first_run:
@@ -82,6 +92,11 @@ class SequentialScheduler:
                 minutes=prompt_config.total_cycle_minutes / len(asset_list)
             )
             next_cycle = next_cycle - timedelta(minutes=1)
+
+        return next_cycle
+
+    @staticmethod
+    def select_delay(next_cycle: datetime) -> int:
         next_cycle_diff = next_cycle - get_current_time()
         delay = int(next_cycle_diff.total_seconds())
         if delay <= 0:
@@ -93,11 +108,52 @@ class SequentialScheduler:
         return delay
 
     @staticmethod
-    def select_asset(latest_asset: str | None, asset_list: list[str]) -> str:
-        asset = asset_list[0]
+    def get_cycle_start_time(
+        next_run_time: datetime, prompt_config: PromptConfig
+    ) -> datetime:
+        total_cycle_minutes = prompt_config.total_cycle_minutes
+        cycle_minute = (
+            next_run_time.minute // total_cycle_minutes
+        ) * total_cycle_minutes
+        return next_run_time.replace(
+            minute=cycle_minute, second=0, microsecond=0
+        )
 
-        if latest_asset is not None and latest_asset in asset_list:
-            latest_index = asset_list.index(latest_asset)
-            asset = asset_list[(latest_index + 1) % len(asset_list)]
+    @staticmethod
+    def shuffle_assets_for_cycle(
+        asset_list: list[str],
+        next_run_time: datetime,
+        prompt_config: PromptConfig,
+        schedule_secret: str,
+    ) -> list[str]:
+        cycle_start_time = SequentialScheduler.get_cycle_start_time(
+            next_run_time, prompt_config
+        )
+        cycle_key = cycle_start_time.astimezone(timezone.utc).isoformat()
+        keyed_assets = [
+            (
+                hashlib.sha256(
+                    f"{schedule_secret}:{cycle_key}:{asset}".encode("utf-8")
+                ).hexdigest(),
+                asset,
+            )
+            for asset in asset_list
+        ]
+        return [asset for _, asset in sorted(keyed_assets)]
 
-        return asset
+    @staticmethod
+    def select_asset(
+        next_run_time: datetime,
+        asset_list: list[str],
+        prompt_config: PromptConfig,
+    ) -> str:
+        cycle_start_time = SequentialScheduler.get_cycle_start_time(
+            next_run_time, prompt_config
+        )
+        slot_seconds = (
+            prompt_config.total_cycle_minutes / len(asset_list)
+        ) * 60
+        elapsed_seconds = (next_run_time - cycle_start_time).total_seconds()
+        slot_index = int(elapsed_seconds // slot_seconds) % len(asset_list)
+
+        return asset_list[slot_index]

--- a/synth/utils/sequential_scheduler.py
+++ b/synth/utils/sequential_scheduler.py
@@ -24,9 +24,9 @@ class SequentialScheduler:
         self.target = target
         self.miner_data_handler = miner_data_handler
         self.first_run = True
-        self.schedule_secret = (
-            os.getenv("VALIDATOR_SCHEDULE_SECRET") or secrets.token_hex(32)
-        )
+        self.schedule_secret = os.getenv(
+            "VALIDATOR_SCHEDULE_SECRET"
+        ) or secrets.token_hex(32)
 
     def start(self):
         cycle_start_time = get_current_time()

--- a/tests/test_sequential_scheduler.py
+++ b/tests/test_sequential_scheduler.py
@@ -20,9 +20,7 @@ def load_scheduler_dependencies():
     miner_data_handler_stub = types.ModuleType(
         "synth.validator.miner_data_handler"
     )
-    miner_data_handler_stub.MinerDataHandler = type(
-        "MinerDataHandler", (), {}
-    )
+    miner_data_handler_stub.MinerDataHandler = type("MinerDataHandler", (), {})
     sys.modules.setdefault(
         "synth.validator.miner_data_handler", miner_data_handler_stub
     )
@@ -129,9 +127,7 @@ def test_select_asset_uses_slot_position_within_cycle():
     )
 
     assert (
-        SequentialScheduler.select_asset(
-            first_slot_time, order, LOW_FREQUENCY
-        )
+        SequentialScheduler.select_asset(first_slot_time, order, LOW_FREQUENCY)
         == order[0]
     )
     assert (

--- a/tests/test_sequential_scheduler.py
+++ b/tests/test_sequential_scheduler.py
@@ -1,31 +1,45 @@
 from datetime import datetime, timezone
+from functools import lru_cache
+import importlib
 import sys
 import types
 
 
-bt_stub = types.SimpleNamespace(
-    logging=types.SimpleNamespace(
-        info=lambda *args, **kwargs: None,
-        exception=lambda *args, **kwargs: None,
+@lru_cache(maxsize=1)
+def load_scheduler_dependencies():
+    bt_stub = types.SimpleNamespace(
+        logging=types.SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            exception=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+        ),
         warning=lambda *args, **kwargs: None,
-    ),
-    warning=lambda *args, **kwargs: None,
-)
-sys.modules.setdefault("bittensor", bt_stub)
+    )
+    sys.modules.setdefault("bittensor", bt_stub)
 
-miner_data_handler_stub = types.ModuleType(
-    "synth.validator.miner_data_handler"
-)
-miner_data_handler_stub.MinerDataHandler = type("MinerDataHandler", (), {})
-sys.modules.setdefault(
-    "synth.validator.miner_data_handler", miner_data_handler_stub
-)
+    miner_data_handler_stub = types.ModuleType(
+        "synth.validator.miner_data_handler"
+    )
+    miner_data_handler_stub.MinerDataHandler = type(
+        "MinerDataHandler", (), {}
+    )
+    sys.modules.setdefault(
+        "synth.validator.miner_data_handler", miner_data_handler_stub
+    )
 
-from synth.utils.sequential_scheduler import SequentialScheduler
-from synth.validator.prompt_config import HIGH_FREQUENCY, LOW_FREQUENCY
+    sequential_scheduler = importlib.import_module(
+        "synth.utils.sequential_scheduler"
+    )
+    prompt_config = importlib.import_module("synth.validator.prompt_config")
+    return (
+        sequential_scheduler.SequentialScheduler,
+        prompt_config.HIGH_FREQUENCY,
+        prompt_config.LOW_FREQUENCY,
+    )
 
 
 def test_shuffle_assets_same_secret_same_cycle_is_stable():
+    SequentialScheduler, _, LOW_FREQUENCY = load_scheduler_dependencies()
     next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
 
     order_1 = SequentialScheduler.shuffle_assets_for_cycle(
@@ -45,6 +59,7 @@ def test_shuffle_assets_same_secret_same_cycle_is_stable():
 
 
 def test_shuffle_assets_different_cycle_changes_order():
+    SequentialScheduler, _, LOW_FREQUENCY = load_scheduler_dependencies()
     cycle_1 = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
     cycle_2 = datetime(2026, 4, 19, 13, 1, tzinfo=timezone.utc)
 
@@ -65,6 +80,7 @@ def test_shuffle_assets_different_cycle_changes_order():
 
 
 def test_shuffle_assets_different_secret_changes_order():
+    SequentialScheduler, _, LOW_FREQUENCY = load_scheduler_dependencies()
     next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
 
     order_1 = SequentialScheduler.shuffle_assets_for_cycle(
@@ -84,6 +100,7 @@ def test_shuffle_assets_different_secret_changes_order():
 
 
 def test_shuffle_assets_preserves_permutation():
+    SequentialScheduler, HIGH_FREQUENCY, _ = load_scheduler_dependencies()
     next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
 
     shuffled = SequentialScheduler.shuffle_assets_for_cycle(
@@ -99,6 +116,7 @@ def test_shuffle_assets_preserves_permutation():
 
 
 def test_select_asset_uses_slot_position_within_cycle():
+    SequentialScheduler, _, LOW_FREQUENCY = load_scheduler_dependencies()
     first_slot_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
     second_slot_time = datetime(2026, 4, 19, 12, 6, tzinfo=timezone.utc)
     last_slot_time = datetime(2026, 4, 19, 12, 56, tzinfo=timezone.utc)

--- a/tests/test_sequential_scheduler.py
+++ b/tests/test_sequential_scheduler.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timezone
+import sys
+import types
+
+
+bt_stub = types.SimpleNamespace(
+    logging=types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        exception=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    ),
+    warning=lambda *args, **kwargs: None,
+)
+sys.modules.setdefault("bittensor", bt_stub)
+
+miner_data_handler_stub = types.ModuleType(
+    "synth.validator.miner_data_handler"
+)
+miner_data_handler_stub.MinerDataHandler = type("MinerDataHandler", (), {})
+sys.modules.setdefault(
+    "synth.validator.miner_data_handler", miner_data_handler_stub
+)
+
+from synth.utils.sequential_scheduler import SequentialScheduler
+from synth.validator.prompt_config import HIGH_FREQUENCY, LOW_FREQUENCY
+
+
+def test_shuffle_assets_same_secret_same_cycle_is_stable():
+    next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
+
+    order_1 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        next_run_time,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+    order_2 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        next_run_time,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+
+    assert order_1 == order_2
+
+
+def test_shuffle_assets_different_cycle_changes_order():
+    cycle_1 = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
+    cycle_2 = datetime(2026, 4, 19, 13, 1, tzinfo=timezone.utc)
+
+    order_1 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        cycle_1,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+    order_2 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        cycle_2,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+
+    assert order_1 != order_2
+
+
+def test_shuffle_assets_different_secret_changes_order():
+    next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
+
+    order_1 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        next_run_time,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+    order_2 = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        next_run_time,
+        LOW_FREQUENCY,
+        "secret-b",
+    )
+
+    assert order_1 != order_2
+
+
+def test_shuffle_assets_preserves_permutation():
+    next_run_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
+
+    shuffled = SequentialScheduler.shuffle_assets_for_cycle(
+        HIGH_FREQUENCY.asset_list,
+        next_run_time,
+        HIGH_FREQUENCY,
+        "secret-a",
+    )
+
+    assert sorted(shuffled) == sorted(HIGH_FREQUENCY.asset_list)
+    assert len(shuffled) == len(HIGH_FREQUENCY.asset_list)
+    assert len(set(shuffled)) == len(HIGH_FREQUENCY.asset_list)
+
+
+def test_select_asset_uses_slot_position_within_cycle():
+    first_slot_time = datetime(2026, 4, 19, 12, 1, tzinfo=timezone.utc)
+    second_slot_time = datetime(2026, 4, 19, 12, 6, tzinfo=timezone.utc)
+    last_slot_time = datetime(2026, 4, 19, 12, 56, tzinfo=timezone.utc)
+
+    order = SequentialScheduler.shuffle_assets_for_cycle(
+        LOW_FREQUENCY.asset_list,
+        first_slot_time,
+        LOW_FREQUENCY,
+        "secret-a",
+    )
+
+    assert (
+        SequentialScheduler.select_asset(
+            first_slot_time, order, LOW_FREQUENCY
+        )
+        == order[0]
+    )
+    assert (
+        SequentialScheduler.select_asset(
+            second_slot_time, order, LOW_FREQUENCY
+        )
+        == order[1]
+    )
+    assert (
+        SequentialScheduler.select_asset(last_slot_time, order, LOW_FREQUENCY)
+        == order[-1]
+    )


### PR DESCRIPTION
## Background
The sequential scheduler currently walks assets in a deterministic order within each cycle. That makes the next requested asset predictable to anyone reading the validator code or observing enough prompts.

## Issue
This predictability creates a fairness problem because code-aware miners can precompute for the next asset, warm caches or model state, and reserve their freshest price pull for the exact next request. In practice, that lets a miner combine schedule knowledge with timing precision to improve anchoring advantage without improving underlying forecast quality.

## Root cause
The implementation selected assets using a deterministic sequence derived from fixed cycle timing and the previously scheduled asset. There was no validator-local secret material in the scheduling path, so the future order was externally inferable.

## Fix
This PR replaces deterministic cycle order with a per-cycle randomized asset order derived from validator-local secret material. The shuffle is deterministic for the validator within a given cycle, but it is not externally predictable to miners.

The patch preserves the existing cadence and slot structure while changing only the order in which assets appear inside each cycle. If `VALIDATOR_SCHEDULE_SECRET` is configured, the order is stable across validator restarts for the same cycle/secret combination. If it is unset, the validator falls back to a process-local random secret so the order remains unpredictable instead of reverting to a predictable sequence.

This approach was chosen because it is minimal, operationally stable, and removes the predictability edge without touching scoring or prompt timing rules.

## Impact
Randomizing per-cycle asset order reduces a real preparation advantage for code-aware miners. They can no longer reliably know the next asset in advance, which makes it harder to precompute, prewarm, or save their freshest anchor for a specific upcoming request. This improves fairness while preserving the validator's overall scheduling cadence.

## Scope / non-goals
This PR fixes asset-order predictability within the existing scheduler.

It intentionally does not:
- change prompt cadence or total request volume
- change scoring math or leaderboard behavior
- change deadline enforcement
- introduce broader protocol changes beyond scheduler hardening

## Risk / compatibility
This changes miner-visible predictability, but it does not change payload shape, scoring rules, or request cadence. The main maintainer consideration is the fallback behavior when `VALIDATOR_SCHEDULE_SECRET` is unset: order stays unpredictable within a process, but it will not be stable across restarts unless operators set the secret explicitly.

## Testing
Tests run:
- `python -m pytest --noconftest tests/test_sequential_scheduler.py -q`
- `python -m py_compile synth/utils/sequential_scheduler.py tests/test_sequential_scheduler.py`

New coverage added:
- same secret + same cycle yields the same order
- different cycle yields a different order
- different secret yields a different order
- shuffled order remains a full permutation with no duplicates or omissions
- slot selection uses the shuffled order inside the cycle

Expected behavior before this patch:
- miners could infer the next asset from deterministic scheduler behavior

Expected behavior after this patch:
- asset order remains deterministic for the validator inside a cycle but is no longer externally predictable to miners

Reviewer note: This is a focused fairness fix and intentionally avoids unrelated scoring/protocol changes.
