### PR TITLE
fix: enforce total per-miner timeout in dendrite forward

### DIFF
--- a/synth/base/dendrite_multiprocess.py
+++ b/synth/base/dendrite_multiprocess.py
@@ -187,10 +187,18 @@ async def call(
         bt.logging.trace(
             f"dendrite | --> | {synapse.get_total_size()} B | {synapse.name} | {synapse.axon.hotkey} | {synapse.axon.ip}:{str(synapse.axon.port)} | 0 | Success"
         )
-        response = await client.post(
-            url=url,
-            headers=synapse.to_headers(),
-            json=synapse_body,
+        # Enforce a total per-miner wall-clock timeout. httpx's `timeout` on
+        # the AsyncClient is per-operation (connect/read/write/pool) and its
+        # `read` timer resets on every received chunk, so a miner that
+        # delivers its body incrementally can keep a request alive well past
+        # `timeout`. Wrapping with asyncio.wait_for bounds the whole call.
+        response = await asyncio.wait_for(
+            client.post(
+                url=url,
+                headers=synapse.to_headers(),
+                json=synapse_body,
+            ),
+            timeout=timeout,
         )
         response.raise_for_status()
         json_response = response.json()


### PR DESCRIPTION
## Summary

- Wrap `client.post(...)` in `synth/base/dendrite_multiprocess.py` with `asyncio.wait_for(..., timeout=timeout)` so each miner call is bounded to `timeout` seconds of wall clock.
- `httpx.AsyncClient(timeout=timeout)` is per-operation, not total — its `read` timer resets on every received chunk, so a miner that streams its body incrementally keeps a request alive past the intended `timeout`. This fix closes that loophole.
- No new error handling: `process_error_message` (`synth/base/dendrite.py:90-92`) already maps `asyncio.TimeoutError` to a clean `"... after {timeout} seconds"` status message, so timed-out miners are recorded exactly like any other error.

## Why

Low-frequency cycle regressed on 2026-04-10 from ~120s to ~997s (`forward_prompt` 994s, dendrite forward alone 778s). No validator code change, no image change, no change in miner count, per-miner response size, or per-miner `process_time`. That set of observations is consistent with a miner-side change in response-delivery *pattern* — each chunk fits inside httpx's `read` timeout, so the request proceeds past `timeout` while `process_time` (measured inside the miner handler) stays flat.

Regardless of whether that is the actual root cause, enforcing a total per-miner wall-clock timeout is the correct behaviour: the README specifies "If [miners] fail to return predictions by the start_time ... they will be scored 0". Today the validator is being *more lenient* than spec.

After this change:
- Each `call()` returns in ≤ `timeout + ε`.
- `asyncio.gather` in each worker returns in ≤ `timeout + ε`.
- Slow-drip miners are recorded with the standard `asyncio.TimeoutError` status, get empty `[]` predictions via `validate_responses_v2`, and score 0 for the prompt.

## Test plan

- [ ] `black --check synth/base/dendrite_multiprocess.py` — passes locally.
- [ ] `flake8 synth/base/dendrite_multiprocess.py` — passes locally.
- [ ] CI green.
- [ ] Staging: one low-frequency cycle — confirm `Forwarding took` ≤ ~`timeout + 15s` even with slow miners.
- [ ] Canary: watch `Execution time for forward_prompt` and the distribution of `format_validation` values in `miner_predictions` for the first cycle after deploy. Expect: forward bounded; small uptick in timed-out miners (the ones previously winning the slow-drip game).

🤖 Generated with [Claude Code](https://claude.com/claude-code)