### PR TITLE
add cycle_interval_minutes CLI args

### DIFF
--- a/docs/validator_guide.md
+++ b/docs/validator_guide.md
@@ -13,6 +13,8 @@
     - [`--sma.high.days INTEGER`](#--smahighdays-integer)
     - [`--softmax.low.beta FLOAT`](#--softmaxlowbeta-float)
     - [`--softmax.high.beta FLOAT`](#--softmaxhighbeta-float)
+    - [`--cycle_interval_minutes.low INTEGER`](#--cycle_interval_minuteslow-integer)
+    - [`--cycle_interval_minutes.high INTEGER`](#--cycle_interval_minuteshigh-integer)
     - [`--logging.debug`](#--loggingdebug)
     - [`--logging.info`](#--logginginfo)
     - [`--logging.trace`](#--loggingtrace)
@@ -416,6 +418,72 @@ Alternatively, you can add the args directly to the command:
 
 ```shell
 pm2 start validator.config.js -- --softmax.high.beta -0.2
+```
+
+<sup>[Back to top ^][table-of-contents]</sup>
+
+#### `--cycle_interval_minutes.low INTEGER`
+
+Cycle interval in minutes for the 24h prompt.
+
+Default: `5`
+
+Example:
+
+```js
+// validator.config.js
+module.exports = {
+  apps: [
+    {
+      name: "validator",
+      interpreter: "python3",
+      script: "./neurons/validator.py",
+      args: "--cycle_interval_minutes.low 5",
+      env: {
+        PYTHONPATH: ".",
+      },
+    },
+  ],
+};
+```
+
+Alternatively, you can add the args directly to the command:
+
+```shell
+pm2 start validator.config.js -- --cycle_interval_minutes.low 5
+```
+
+<sup>[Back to top ^][table-of-contents]</sup>
+
+#### `--cycle_interval_minutes.high INTEGER`
+
+Cycle interval in minutes for the 1h prompt.
+
+Default: `2`
+
+Example:
+
+```js
+// validator.config.js
+module.exports = {
+  apps: [
+    {
+      name: "validator",
+      interpreter: "python3",
+      script: "./neurons/validator.py",
+      args: "--cycle_interval_minutes.high 2",
+      env: {
+        PYTHONPATH: ".",
+      },
+    },
+  ],
+};
+```
+
+Alternatively, you can add the args directly to the command:
+
+```shell
+pm2 start validator.config.js -- --cycle_interval_minutes.high 2
 ```
 
 <sup>[Back to top ^][table-of-contents]</sup>

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -83,6 +83,12 @@ class Validator(BaseValidatorNeuron):
         HIGH_FREQUENCY.window_days = self.config.sma.high.days
         LOW_FREQUENCY.data_retention_days = self.config.retention.low.days
         HIGH_FREQUENCY.data_retention_days = self.config.retention.high.days
+        LOW_FREQUENCY.cycle_interval_minutes = (
+            self.config.cycle_interval_minutes.low
+        )
+        HIGH_FREQUENCY.cycle_interval_minutes = (
+            self.config.cycle_interval_minutes.high
+        )
 
         PriceDataProvider.assert_assets_supported(HIGH_FREQUENCY.asset_list)
         PriceDataProvider.assert_assets_supported(LOW_FREQUENCY.asset_list)

--- a/synth/utils/config.py
+++ b/synth/utils/config.py
@@ -292,6 +292,20 @@ def add_validator_args(_, parser: argparse.ArgumentParser):
         default=-0.2,
     )
 
+    parser.add_argument(
+        "--cycle_interval_minutes.low",
+        type=int,
+        help="Cycle interval in minutes for the low frequency prompt.",
+        default=5,
+    )
+
+    parser.add_argument(
+        "--cycle_interval_minutes.high",
+        type=int,
+        help="Cycle interval in minutes for the high frequency prompt.",
+        default=2,
+    )
+
 
 def config(cls):
     """


### PR DESCRIPTION
## Summary
- Expose `--cycle_interval_minutes.low` / `--cycle_interval_minutes.high` and apply them to `LOW_FREQUENCY` / `HIGH_FREQUENCY` in `Validator.__init__`, matching the existing softmax/sma/retention override pattern.

## Test plan
- [ ] Run validator with defaults — cycle intervals stay at 5 / 2 minutes.
- [ ] Run validator with `--cycle_interval_minutes.low 10 --cycle_interval_minutes.high 3` — overrides take effect.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>