### PR TITLE
feat: integrate Fiber for validator IP registration and miner axon ve…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,5 @@ repos:
     rev: 7.1.2
     hooks:
       - id: flake8
+        # required for flake8 to read [tool.flake8] from pyproject.toml
+        additional_dependencies: [Flake8-pyproject==1.2.3]

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -103,6 +103,13 @@ class Miner(BaseMinerNeuron):
             return True, "Unrecognized hotkey"
 
         uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+
+        if not self.metagraph.axons[uid].is_serving:
+            bt.logging.info(
+                f"Denying hotkey {synapse.dendrite.hotkey}: no registered axon on-chain"
+            )
+            return True, "No registered axon"
+
         stake = self.metagraph.S[uid]
         bt.logging.info(f"Requesting UID: {uid} | Stake at UID: {stake}")
         if stake <= self.config.blacklist.validator_min_stake:

--- a/synth/base/validator.py
+++ b/synth/base/validator.py
@@ -65,11 +65,14 @@ class BaseValidatorNeuron(BaseNeuron):
         # Init sync with the network. Updates the metagraph.
         self.sync()
 
-        # Serve axon to enable external connections.
+        # Register egress IP on-chain via Fiber (regardless of axon_off).
+        self.register_ip_via_fiber()
+
+        # Optionally serve a local axon HTTP server for external connections.
         if not self.config.neuron.axon_off:
             self.serve_axon()
         else:
-            bt.logging.warning("axon off, not serving ip to chain.")
+            bt.logging.warning("axon off, not starting local axon server.")
 
         # Create asyncio event loop to manage async tasks.
         self.loop = asyncio.get_event_loop()
@@ -101,6 +104,61 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.error(
                 f"Failed to create Axon initialize with exception: {e}"
             )
+
+    def register_ip_via_fiber(self):
+        """Detect egress IP and register it on-chain using Fiber."""
+        import os
+        import httpx as _httpx
+        from fiber.chain import interface as fiber_interface
+        from fiber.chain import post_ip_to_chain
+
+        external_ip = os.environ.get("EXTERNAL_IP")
+        if external_ip:
+            bt.logging.info(f"Using EXTERNAL_IP from environment: {external_ip}")
+        else:
+            try:
+                resp = _httpx.get("https://checkip.amazonaws.com", timeout=10)
+                resp.raise_for_status()
+                external_ip = resp.text.strip()
+            except Exception as e:
+                bt.logging.error(f"Failed to detect egress IP: {e}")
+                return
+
+        external_port = self.config.axon.port
+
+        chain_endpoint = getattr(self.config.subtensor, "chain_endpoint", None)
+        network = getattr(self.config.subtensor, "network", None)
+        substrate = fiber_interface.get_substrate(
+            subtensor_address=chain_endpoint,
+            subtensor_network=network,
+        )
+
+        hotkey_keypair = self.wallet.hotkey
+        coldkey_ss58 = self.wallet.coldkeypub.ss58_address
+
+        bt.logging.info(
+            f"Registering egress IP {external_ip}:{external_port} on-chain via Fiber..."
+        )
+
+        try:
+            success = post_ip_to_chain.post_node_ip_to_chain(
+                substrate=substrate,
+                keypair=hotkey_keypair,
+                netuid=self.config.netuid,
+                external_ip=external_ip,
+                external_port=external_port,
+                coldkey_ss58_address=coldkey_ss58,
+            )
+        except Exception as e:
+            bt.logging.error(f"Fiber IP registration extrinsic failed: {e}")
+            return
+
+        if success:
+            bt.logging.info(
+                f"Registered egress IP {external_ip}:{external_port} on-chain via Fiber"
+            )
+        else:
+            bt.logging.error("Failed to register IP on-chain via Fiber")
 
     def run(self):
         """

--- a/synth/base/validator.py
+++ b/synth/base/validator.py
@@ -19,13 +19,18 @@
 
 
 import copy
+import os
 import numpy as np
 import asyncio
 import argparse
 import threading
 import bittensor as bt
+import httpx
 
 from typing import List, Union
+
+from fiber.chain import interface as fiber_interface
+from fiber.chain import post_ip_to_chain
 
 from synth.base.dendrite import SynthDendrite
 from synth.base.neuron import BaseNeuron
@@ -107,11 +112,6 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def register_ip_via_fiber(self):
         """Detect egress IP and register it on-chain using Fiber."""
-        import os
-        import httpx as _httpx
-        from fiber.chain import interface as fiber_interface
-        from fiber.chain import post_ip_to_chain
-
         external_ip = os.environ.get("EXTERNAL_IP")
         if external_ip:
             bt.logging.info(
@@ -119,7 +119,7 @@ class BaseValidatorNeuron(BaseNeuron):
             )
         else:
             try:
-                resp = _httpx.get("https://checkip.amazonaws.com", timeout=10)
+                resp = httpx.get("https://checkip.amazonaws.com", timeout=10)
                 resp.raise_for_status()
                 external_ip = resp.text.strip()
             except Exception as e:

--- a/synth/base/validator.py
+++ b/synth/base/validator.py
@@ -114,7 +114,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
         external_ip = os.environ.get("EXTERNAL_IP")
         if external_ip:
-            bt.logging.info(f"Using EXTERNAL_IP from environment: {external_ip}")
+            bt.logging.info(
+                f"Using EXTERNAL_IP from environment: {external_ip}"
+            )
         else:
             try:
                 resp = _httpx.get("https://checkip.amazonaws.com", timeout=10)


### PR DESCRIPTION
…rification

- Add chutesai/fiber dependency for on-chain IP registration
- Validator: auto-detect egress IP and register on-chain via Fiber's post_node_ip_to_chain on every startup (regardless of axon_off flag)
- Validator: support EXTERNAL_IP env var to override auto-detection
- Miner: reject requests from validators without a registered axon (is_serving check before stake threshold)