### PR TITLE
add one-time script to trim score_details_v3 crps_data to totals

### DIFF
--- a/tests/test_trim_score_details_v3.py
+++ b/tests/test_trim_score_details_v3.py
@@ -1,0 +1,86 @@
+import unittest
+
+from verify.trim_score_details_v3 import trim_crps_data
+
+
+class TestTrimCrpsData(unittest.TestCase):
+    def test_drops_increment_rows_keeps_totals(self):
+        crps_data = [
+            {"Interval": "5min", "Increment": 1, "CRPS": 1.0},
+            {"Interval": "5min", "Increment": 2, "CRPS": 2.0},
+            {"Interval": "5min", "Increment": "Total", "CRPS": 3.0},
+            {"Interval": "30min", "Increment": 1, "CRPS": 4.0},
+            {"Interval": "30min", "Increment": "Total", "CRPS": 4.0},
+            {"Interval": "Overall", "Increment": "Total", "CRPS": 7.0},
+        ]
+
+        result = trim_crps_data(crps_data)
+
+        self.assertEqual(
+            result,
+            [
+                {"Interval": "5min", "Increment": "Total", "CRPS": 3.0},
+                {"Interval": "30min", "Increment": "Total", "CRPS": 4.0},
+                {"Interval": "Overall", "Increment": "Total", "CRPS": 7.0},
+            ],
+        )
+
+    def test_reconstructs_gap_total_before_overall(self):
+        crps_data = [
+            {"Interval": "1min", "Increment": 1, "CRPS": 1.0},
+            {"Interval": "1min", "Increment": "Total", "CRPS": 1.0},
+            {"Interval": "0_5min_gaps", "Increment": 1, "CRPS": 2.0},
+            {"Interval": "0_5min_gaps", "Increment": "Total", "CRPS": 2.0},
+            {"Interval": "0_10min_gaps", "Increment": 1, "CRPS": 3.0},
+            {"Interval": "0_10min_gaps", "Increment": "Total", "CRPS": 3.0},
+            {"Interval": "Overall", "Increment": "Total", "CRPS": 6.0},
+        ]
+
+        result = trim_crps_data(crps_data)
+
+        self.assertEqual(
+            result,
+            [
+                {"Interval": "1min", "Increment": "Total", "CRPS": 1.0},
+                {"Interval": "0_5min_gaps", "Increment": "Total", "CRPS": 2.0},
+                {
+                    "Interval": "0_10min_gaps",
+                    "Increment": "Total",
+                    "CRPS": 3.0,
+                },
+                # gap total = 2.0 + 3.0, inserted right before Overall
+                {"Interval": "Gaps", "Increment": "Total", "CRPS": 5.0},
+                {"Interval": "Overall", "Increment": "Total", "CRPS": 6.0},
+            ],
+        )
+
+    def test_no_gaps_adds_no_aggregate(self):
+        crps_data = [
+            {"Interval": "5min", "Increment": 1, "CRPS": 1.0},
+            {"Interval": "5min", "Increment": "Total", "CRPS": 1.0},
+            {"Interval": "Overall", "Increment": "Total", "CRPS": 1.0},
+        ]
+
+        result = trim_crps_data(crps_data)
+
+        self.assertNotIn("Gaps", [d["Interval"] for d in result])
+
+    def test_idempotent(self):
+        crps_data = [
+            {"Interval": "0_5min_gaps", "Increment": 1, "CRPS": 2.0},
+            {"Interval": "0_5min_gaps", "Increment": "Total", "CRPS": 2.0},
+            {"Interval": "Overall", "Increment": "Total", "CRPS": 2.0},
+        ]
+
+        once = trim_crps_data(crps_data)
+        twice = trim_crps_data(once)
+
+        self.assertEqual(once, twice)
+
+    def test_error_payload_left_untouched(self):
+        crps_data = [{"error": "Zero price encountered in simulation runs"}]
+        self.assertEqual(trim_crps_data(crps_data), crps_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verify/trim_score_details_v3.py
+++ b/verify/trim_score_details_v3.py
@@ -1,0 +1,137 @@
+"""One-time migration: shrink miner_scores.score_details_v3.crps_data.
+
+Historical rows stored a verbose ``crps_data`` list with one entry per scoring
+increment (``Increment`` = 1, 2, 3, ...) alongside the per-interval ``Total``
+rows. PR #273 changed the live writer (``crps_calculation.py``) to keep only:
+
+  * one ``Total`` row per scoring interval,
+  * an aggregate ``{"Interval": "Gaps", "Increment": "Total"}`` row (when any
+    ``*_gaps`` interval scored), and
+  * the final ``{"Interval": "Overall", "Increment": "Total"}`` row.
+
+This rewrites the old rows into that shape so the column is uniform and far
+smaller. The per-increment detail is intentionally discarded.
+
+The aggregate gap total is reconstructed by summing the per-interval ``Total``
+of every interval whose name ends with ``_gaps`` — the same value the new
+writer accumulates, and all that survives in already-trimmed rows.
+
+Idempotent: re-running recomputes the identical list and skips the write.
+Dry run by default; pass ``--apply`` to persist.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import bittensor as bt
+from dotenv import load_dotenv
+from sqlalchemy import select, update
+
+from synth.db.models import MinerScore, get_engine
+
+load_dotenv()
+
+
+def trim_crps_data(crps_data: list[dict]) -> list[dict]:
+    """Reduce a verbose ``crps_data`` list to the post-#273 shape.
+
+    Keeps the per-interval ``Total`` rows, appends a reconstructed
+    ``Gaps``/``Total`` aggregate, then the ``Overall``/``Total`` row — matching
+    the order the live writer produces. Error payloads (e.g.
+    ``[{"error": ...}]``) and anything without ``Total`` rows are left as-is.
+    """
+    if not isinstance(crps_data, list):
+        return crps_data
+
+    totals = [d for d in crps_data if d.get("Increment") == "Total"]
+    if not totals:
+        return crps_data
+
+    # Drop any existing aggregate so a re-run recomputes from scratch (keeps
+    # the function idempotent).
+    totals = [d for d in totals if d.get("Interval") != "Gaps"]
+
+    gap_total = sum(
+        d["CRPS"]
+        for d in totals
+        if str(d.get("Interval", "")).endswith("_gaps")
+    )
+
+    overall = [d for d in totals if d.get("Interval") == "Overall"]
+    trimmed = [d for d in totals if d.get("Interval") != "Overall"]
+    if gap_total > 0:
+        trimmed.append(
+            {"Interval": "Gaps", "Increment": "Total", "CRPS": gap_total}
+        )
+    trimmed.extend(overall)
+    return trimmed
+
+
+def main(apply: bool, batch_size: int) -> None:
+    engine = get_engine()
+    after_id = 0
+    scanned = 0
+    changed = 0
+
+    while True:
+        with engine.begin() as connection:
+            rows = connection.execute(
+                select(MinerScore.id, MinerScore.score_details_v3)
+                .where(MinerScore.id > after_id)
+                .order_by(MinerScore.id)
+                .limit(batch_size)
+            ).all()
+            if not rows:
+                break
+
+            updates = []
+            for row in rows:
+                details = row.score_details_v3
+                if not isinstance(details, dict):
+                    continue
+                crps_data = details.get("crps_data")
+                if crps_data is None:
+                    continue
+                trimmed = trim_crps_data(crps_data)
+                if trimmed == crps_data:
+                    continue
+                updates.append((row.id, {**details, "crps_data": trimmed}))
+
+            if apply:
+                for score_id, new_details in updates:
+                    connection.execute(
+                        update(MinerScore)
+                        .where(MinerScore.id == score_id)
+                        .values(score_details_v3=new_details)
+                    )
+
+        scanned += len(rows)
+        changed += len(updates)
+        after_id = rows[-1].id
+        bt.logging.info(
+            f"trim progress: scanned={scanned} changed={changed} "
+            f"(last id={after_id})"
+        )
+
+    verb = "updated" if apply else "would update (dry run)"
+    bt.logging.info(f"trim done: {verb} {changed}/{scanned} rows")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Trim miner_scores.score_details_v3 crps_data to Totals."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="persist changes (default: dry run, no writes)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="rows scanned per id-keyset batch (default: 1000)",
+    )
+    args = parser.parse_args()
+    main(apply=args.apply, batch_size=args.batch_size)


### PR DESCRIPTION
PR #273 changed the live writer to keep only the per-interval "Total" rows, an aggregate "Gaps"/"Total" row, and the "Overall"/"Total" row in detailed_crps_data, dropping the verbose per-increment entries.

This adds verify/trim_score_details_v3.py to rewrite the historical miner_scores.score_details_v3 rows into that same shape so the column is uniform and far smaller. The aggregate gap total is reconstructed by summing the per-interval "Total" of every interval whose name ends with "_gaps" — the same value the new writer accumulates.

Keyset-paginated by id, idempotent (re-running recomputes the identical list and skips the write), and dry-run by default (--apply to persist).