### PR TITLE
fix(miner): reject unsigned requests in blacklist

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -92,6 +92,13 @@ class Miner(BaseMinerNeuron):
             )
             return True, "Missing dendrite or hotkey"
 
+        if not synapse.dendrite.signature:
+            bt.logging.warning(
+                f"Blacklisting unsigned request claiming hotkey "
+                f"{synapse.dendrite.hotkey}"
+            )
+            return True, "Missing signature"
+
         if (
             not self.config.blacklist.allow_non_registered
             and synapse.dendrite.hotkey not in self.metagraph.hotkeys


### PR DESCRIPTION
## Summary

Rejects requests with an empty/absent `synapse.dendrite.signature` in `Miner.blacklist`, before they reach `forward()`.

## Why

`bittensor.core.axon.Axon.default_verify` gates the cryptographic signature check behind `if synapse.dendrite.signature`:

```python
if synapse.dendrite.signature and not keypair.verify(message, synapse.dendrite.signature):
    raise Exception("Signature mismatch ...")
```

A request with an empty/absent signature short-circuits the `and`, **skipping verification entirely**. The request then falls through to "Success" and reaches `blacklist`/`forward` as if it had been genuinely signed by the claimed dendrite hotkey. An attacker can put any registered high-stake validator's SS58 in `bt_header_dendrite_hotkey`, send **no** signature, and pass the blacklist's `validator_permit`/`min_stake` checks — letting them harvest miner predictions while masquerading as a real validator, with no secret material required.

This was observed in the wild: a victim miner's axon log showed `200 | Success` for requests claiming our validator hotkey but originating from foreign IPs (`178.128.88.40`, `194.5.52.21`, etc.), with the same `(asset, start_time)` arriving from both our legit egress and the attacker IPs within seconds.

A present-but-invalid signature is already correctly rejected by `default_verify` (`keypair.verify` returns False → 401). The only hole is the empty case, which this PR closes at the application layer.

## Test plan

- [ ] Send a forged request with `bt_header_dendrite_signature: ""` claiming a registered validator hotkey — blacklist now returns `(True, "Missing signature")` and the miner does not run `forward()`.
- [ ] Send a request with a present-but-invalid signature — still rejected at `default_verify` with 401 Signature mismatch (unchanged).
- [ ] Send a normally-signed request from a real dendrite — passes blacklist and is served (unchanged).

## Notes

- This is a stopgap. The durable fix belongs upstream in `bittensor.core.axon.Axon.default_verify` (require the signature to be present before verifying).
- Pairs well with kernel-level mitigations like a UFW allowlist of validator IPs from the metagraph, since the relay attacker's hosts are not validators and would be dropped at the firewall layer regardless of signature handling.