### PR TITLE
fix(config): enable bittensor CLI arg parsing (BT_NO_PARSE_CLI_ARGS)

### DIFF
--- a/synth/utils/config.py
+++ b/synth/utils/config.py
@@ -275,6 +275,13 @@ def config(cls):
     """
     Returns the configuration object specific to this miner or validator after adding relevant arguments.
     """
+    # bittensor 10.4.x disables CLI argument parsing unless BT_NO_PARSE_CLI_ARGS
+    # is explicitly falsy (it defaults to "true"). Our neurons are configured
+    # entirely through CLI flags, so without this bt.Config(parser) ignores
+    # every --flag and returns only DEFAULTS (config.neuron is None, subtensor
+    # on finney, etc.). Scoped here (not module level) so it only affects
+    # neuron config building, never bittensor's logging machine under pytest.
+    os.environ.setdefault("BT_NO_PARSE_CLI_ARGS", "false")
     parser = argparse.ArgumentParser()
     bt.Wallet.add_args(parser)
     bt.Subtensor.add_args(parser)


### PR DESCRIPTION
## Problem

On bittensor `10.4.x`, the validator (and miner) crash at startup:

```
File "synth/utils/config.py", line 58, in check_config
    config.neuron.name,
AttributeError: 'NoneType' object has no attribute 'name'
```

## Root cause

bittensor 10.4.x **disables CLI argument parsing by default**: `bittensor.core.config.Config.__init__` early-returns when `no_parse_cli()` is true, and `no_parse_cli()` reads `BT_NO_PARSE_CLI_ARGS` which **defaults to `"true"`**. So `bt.Config(parser)` skips parsing entirely and returns only `DEFAULTS`:

- `config.neuron` is `None` → `check_config` crash above
- `config.netuid` is dropped
- `config.subtensor.network` stays `finney` (ignores `--subtensor.network test`)

i.e. every `--flag` from `entrypoint-validator.sh` / `entrypoint-miner.sh` was silently ignored. This regressed when the repo moved to `bittensor==10.4.1`.

## Fix

Set `BT_NO_PARSE_CLI_ARGS=false` inside `config()` before building `bt.Config`, so the neurons are configured from their CLI flags again. It's scoped to `config()` (not module import) so it never makes bittensor's logging machine parse pytest's argv during the test suite, and uses `setdefault` so an operator can still override.

One line covers both validator and miner (they share `config()`).

## Verification

With the fix, `Validator.config()` built from a realistic argv resolves correctly and `check_config()` passes:

- `netuid=247`, `subtensor.network=test`, `wallet.name`, `neuron.name/nprocs`, `retention.low.days`, `validator.mode`, `storage.backend`
- `check_config()` no longer raises; `neuron.full_path` computes
- unit tests green; `black`/`flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)