### PR TITLE
test+tooling: QA coverage for the 3-competition split

### DIFF
--- a/scripts/check_competition_rewards.py
+++ b/scripts/check_competition_rewards.py
@@ -1,0 +1,112 @@
+"""Read-only Layer-2 soak check for the 3-competition split.
+
+Run with the SAME environment as the validator (Postgres creds:
+POSTGRES_USER/PASSWORD/HOST/PORT/DB, and PYTHONPATH=.). Reads only — plain
+SELECTs against the validator's Postgres, no writes.
+
+Verifies, against live validator data:
+  - per-competition reward_weight sums for the latest scoring cycle
+    (each `prompt_name` should be ~1/3 = SMOOTHED_SCORE_COEFFICIENT, and the
+    miner total ~1.0 once the owner/burn row is added);
+  - recent miner_scores volume per (asset, time_length) competition slice;
+  - the most recent weights_update_history rows resolved SUCCESS.
+
+    python scripts/check_competition_rewards.py
+"""
+
+from dotenv import load_dotenv
+from sqlalchemy import text
+
+from synth.validator import competition_config
+from synth.validator.miner_data_handler import MinerDataHandler
+
+SCORES_LOOKBACK_HOURS = 24
+WEIGHTS_TO_SHOW = 5
+
+
+def main() -> None:
+    load_dotenv()
+    engine = MinerDataHandler().engine
+    expected = competition_config.SMOOTHED_SCORE_COEFFICIENT
+    labels = {c.label for c in competition_config.ALL_COMPETITIONS}
+
+    with engine.connect() as conn:
+        # --- per-competition reward_weight sums for the latest cycle ---
+        latest = conn.execute(
+            text("SELECT max(updated_at) FROM miner_rewards")
+        ).scalar()
+        print(f"latest miner_rewards.updated_at: {latest}")
+        print(
+            f"\n{'prompt_name':28} {'#miners':>8} {'Σ reward_weight':>16} "
+            f"{'vs 1/3':>10}"
+        )
+        print("-" * 66)
+        rows = conn.execute(
+            text("""
+                SELECT prompt_name,
+                       count(DISTINCT miner_id) AS n,
+                       sum(reward_weight) AS total
+                FROM miner_rewards
+                WHERE updated_at = :latest
+                GROUP BY prompt_name
+                ORDER BY prompt_name
+                """),
+            {"latest": latest},
+        ).fetchall()
+        for r in rows:
+            flag = "" if r.prompt_name in labels else "  <-- UNKNOWN LABEL"
+            delta = (r.total or 0) - expected
+            print(
+                f"{str(r.prompt_name):28} {r.n:>8} {r.total or 0:>16.6f} "
+                f"{delta:>+10.6f}{flag}"
+            )
+        present = {r.prompt_name for r in rows}
+        missing = labels - present
+        if missing:
+            print(f"  MISSING competitions this cycle: {sorted(missing)}")
+
+        # --- recent score volume per (asset, time_length) ---
+        print(
+            f"\nminer_scores in the last {SCORES_LOOKBACK_HOURS}h "
+            f"per (asset, time_length):"
+        )
+        print(f"{'asset':8} {'time_len':>8} {'#scores':>8} {'#miners':>8}")
+        print("-" * 36)
+        score_rows = conn.execute(
+            text("""
+                SELECT vr.asset, vr.time_length,
+                       count(*) AS n,
+                       count(DISTINCT mp.miner_id) AS miners
+                FROM miner_scores ms
+                JOIN miner_predictions mp ON mp.id = ms.miner_predictions_id
+                JOIN validator_requests vr ON vr.id = mp.validator_requests_id
+                WHERE ms.scored_time > now() - make_interval(
+                    hours => :hours)
+                GROUP BY vr.asset, vr.time_length
+                ORDER BY vr.asset, vr.time_length
+                """),
+            {"hours": SCORES_LOOKBACK_HOURS},
+        ).fetchall()
+        for r in score_rows:
+            print(
+                f"{str(r.asset):8} {r.time_length:>8} {r.n:>8} {r.miners:>8}"
+            )
+
+        # --- recent on-chain weight sets ---
+        print(f"\nlast {WEIGHTS_TO_SHOW} weights_update_history rows:")
+        wh = conn.execute(
+            text("""
+                SELECT updated_at, update_result,
+                       jsonb_array_length(norm_miner_weights::jsonb) AS n
+                FROM weights_update_history
+                ORDER BY updated_at DESC
+                LIMIT :lim
+                """),
+            {"lim": WEIGHTS_TO_SHOW},
+        ).fetchall()
+        for r in wh:
+            print(f"  {r.updated_at}  {r.update_result}  (n_uids={r.n})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_testnet_predictions.py
+++ b/scripts/check_testnet_predictions.py
@@ -1,0 +1,105 @@
+"""Read-only check: do we have (valid) miner predictions per competition?
+
+Run with the SAME environment as the validator — Postgres creds
+(POSTGRES_USER/PASSWORD/HOST/PORT/DB), Bigtable (BIGTABLE_PROJECT,
+BIGTABLE_INSTANCE, BIGTABLE_TABLE_PREDICTION_LOW, BIGTABLE_TABLE_PREDICTION_HIGH),
+GOOGLE_APPLICATION_CREDENTIALS, and PYTHONPATH=. — so it points at the
+same testnet PG + Bigtable instance the validator writes to.
+
+Read-only: it only SELECTs from Postgres and range-reads Bigtable; it never
+writes or deletes. For each asset seen in the last LOOKBACK_HOURS it reports
+how many validator_requests exist, and (by hydrating a few recent ones from
+Bigtable) how many predictions arrived and how many are valid.
+
+    python verify/check_testnet_predictions.py
+"""
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from dotenv import load_dotenv
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from synth.db.models import ValidatorRequest
+from synth.validator import competition_config, response_validation_v2
+from synth.validator.bigtable_prediction_storage import (
+    BigtablePredictionStorage,
+)
+from synth.validator.miner_data_handler import MinerDataHandler
+
+LOOKBACK_HOURS = 6
+# How many recent requests per (asset, time_length) to hydrate from Bigtable.
+SAMPLE_PER_GROUP = 3
+
+
+def _asset_to_competition() -> dict[tuple[str, int], str]:
+    # Keyed on (asset, time_length): the same asset (e.g. BTC) belongs to both
+    # CRYPTO_1H and CRYPTO_24H, so the time_length is what disambiguates them.
+    mapping: dict[tuple[str, int], str] = {}
+    for comp in competition_config.ALL_COMPETITIONS:
+        for asset in comp.asset_list:
+            mapping.setdefault((asset, comp.time_length), comp.label)
+    return mapping
+
+
+def main() -> None:
+    load_dotenv()
+    handler = MinerDataHandler(bigtable_storage=BigtablePredictionStorage())
+    since = datetime.now(timezone.utc) - timedelta(hours=LOOKBACK_HOURS)
+    asset_comp = _asset_to_competition()
+
+    with Session(handler.engine) as session:
+        requests = (
+            session.execute(
+                select(ValidatorRequest)
+                .where(ValidatorRequest.start_time > since)
+                .order_by(ValidatorRequest.start_time.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+        by_group: dict[tuple, list] = defaultdict(list)
+        for vr in requests:
+            by_group[(vr.asset, vr.time_length)].append(vr)
+
+        print(
+            f"validator_requests in the last {LOOKBACK_HOURS}h: "
+            f"{len(requests)} across {len(by_group)} (asset, time_length) groups"
+        )
+        header = (
+            f"\n{'asset':8} {'time_len':>8} {'competition':26} "
+            f"{'#req':>5} {'#pred':>7} {'#valid':>7}  sample_price"
+        )
+        print(header)
+        print("-" * len(header))
+
+        for (asset, time_length), reqs in sorted(by_group.items()):
+            comp = asset_comp.get(
+                (asset, time_length), "(not in any competition)"
+            )
+            n_pred = n_valid = 0
+            sample_price = ""
+            for vr in reqs[:SAMPLE_PER_GROUP]:
+                preds = handler.get_predictions_by_request(vr) or []
+                n_pred += len(preds)
+                for p in preds:
+                    if (
+                        p.format_validation == response_validation_v2.CORRECT
+                        and p.prediction
+                        and len(p.prediction) > 2
+                        and p.prediction[2]
+                    ):
+                        n_valid += 1
+                        if not sample_price:
+                            # prediction = [start_ts, increment, [path], ...]
+                            sample_price = p.prediction[2][0]
+            print(
+                f"{asset:8} {time_length:>8} {comp:26} "
+                f"{len(reqs):>5} {n_pred:>7} {n_valid:>7}  {sample_price}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta, timezone
 import logging
 from unittest.mock import patch
 
+import pytest
+
 # from numpy.testing import assert_almost_equal
 import bittensor as bt
 
@@ -14,7 +16,13 @@ from synth.validator.forward import (
     calculate_moving_average_and_update_rewards,
     calculate_scores,
 )
-from synth.db.models import Miner, MinerReward
+from synth.db.models import (
+    Miner,
+    MinerPrediction,
+    MinerReward,
+    MinerScore,
+    ValidatorRequest,
+)
 from synth.validator.miner_data_handler import MinerDataHandler
 from synth.validator.price_data_provider import PriceDataProvider
 from synth.validator import competition_config
@@ -335,6 +343,108 @@ def test_calculate_moving_average_and_update_rewards_new_miner_registration(
         ]
         print("sum miner_weights", sum(miner_weights))
         # assert_almost_equal(sum(miner_weights), 0.5, decimal=12)
+
+
+def _seed_competition_scores(engine, comp, miner_ids, scores, scored_time):
+    """Insert validator_request + miner_predictions + miner_scores for one
+    competition's first asset, so calculate_moving_average_and_update_rewards
+    can score it without any live price fetch."""
+    now = datetime.now(timezone.utc)
+    with engine.connect() as connection:
+        with connection.begin():
+            vr_id = connection.execute(
+                insert(ValidatorRequest)
+                .values(
+                    start_time=scored_time
+                    - timedelta(seconds=comp.time_length),
+                    asset=comp.asset_list[0],
+                    time_length=comp.time_length,
+                    time_increment=comp.time_increment,
+                    num_simulations=1,
+                )
+                .returning(ValidatorRequest.id)
+            ).scalar_one()
+            for miner_id, score in zip(miner_ids, scores):
+                mp_id = connection.execute(
+                    insert(MinerPrediction)
+                    .values(
+                        validator_requests_id=vr_id,
+                        miner_uid=miner_id,
+                        miner_id=miner_id,
+                        prediction=[],
+                        format_validation=response_validation_v2.CORRECT,
+                        created_at=now,
+                    )
+                    .returning(MinerPrediction.id)
+                ).scalar_one()
+                connection.execute(
+                    insert(MinerScore).values(
+                        miner_uid=miner_id,
+                        scored_time=scored_time,
+                        miner_predictions_id=mp_id,
+                        prompt_score=score,
+                        prompt_score_v3=score,
+                        score_details={},
+                        score_details_v3={
+                            "percentile90": 0.01,
+                            "lowest_score": 0.0,
+                        },
+                    )
+                )
+
+
+def test_moving_average_writes_all_three_competitions(db_engine: Engine):
+    """End-to-end (DB, no live prices): the moving-average update iterates
+    ALL_COMPETITIONS, writes miner_rewards under each competition's label, and
+    the combined weights sum to ~1.0 (3 competitions x SMOOTHED_SCORE_COEFFICIENT).
+    """
+    handler = MinerDataHandler(db_engine)
+    miner_ids = [90101, 90102]  # high ids to avoid collision with other tests
+    scored_time = datetime.now(timezone.utc) - timedelta(hours=1)
+
+    now = datetime.now(timezone.utc)
+    with db_engine.connect() as connection:
+        with connection.begin():
+            connection.execute(
+                insert(Miner).values(
+                    [
+                        {
+                            "id": m,
+                            "miner_uid": m,
+                            "created_at": now,
+                            "updated_at": now,
+                        }
+                        for m in miner_ids
+                    ]
+                )
+            )
+
+    for comp in competition_config.ALL_COMPETITIONS:
+        _seed_competition_scores(
+            db_engine, comp, miner_ids, [0.002, 0.004], scored_time
+        )
+
+    combined = calculate_moving_average_and_update_rewards(
+        miner_data_handler=handler,
+        scored_time=scored_time,
+    )
+
+    # All three competition labels were written to miner_rewards for our miners.
+    with db_engine.connect() as connection:
+        labels = {
+            row.prompt_name
+            for row in connection.execute(
+                select(MinerReward.prompt_name).where(
+                    MinerReward.miner_id.in_(miner_ids)
+                )
+            ).fetchall()
+        }
+    assert labels == {c.label for c in competition_config.ALL_COMPETITIONS}
+
+    # Each competition contributes SMOOTHED_SCORE_COEFFICIENT, so the combined
+    # per-miner weights sum to ~1.0 across the three competitions.
+    total = sum(item["reward_weight"] for item in combined)
+    assert total == pytest.approx(1.0, abs=1e-6)
 
 
 @patch("synth.miner.simulations.get_asset_price", return_value=90000.0)

--- a/tests/test_moving_average_unit.py
+++ b/tests/test_moving_average_unit.py
@@ -24,6 +24,7 @@ from synth.validator.moving_average import (
     prepare_df_for_moving_average,
 )
 from synth.validator.competition_config import (
+    COM_EQU_24H,
     CRYPTO_1H,
     CRYPTO_24H,
     SMOOTHED_SCORE_COEFFICIENT,
@@ -460,6 +461,22 @@ class TestComputeSmoothedScore:
         assert result is not None
         assert result[0]["prompt_name"] == "Crypto 1h"
 
+    def test_com_equ_competition_config(self):
+        """COM_EQU_24H sets its label and scores its assets, including the
+        SPCX feed added in the split (must have an ASSET_COEFFICIENTS entry).
+        """
+        times = [_ts(0), _ts(60)]
+        df = _make_scores_df(
+            [1], times, assets=["SPCX", "XAU"], scores=[0.005]
+        )
+        df = prepare_df_for_moving_average(df)
+
+        handler = _mock_handler({1: 10})
+        result = compute_smoothed_score(handler, df, _ts(120), COM_EQU_24H)
+
+        assert result is not None
+        assert result[0]["prompt_name"] == "Commodities/Equities 24h"
+
     def test_better_miner_gets_more_weight(self):
         """Miner with lower scores (better) should get higher reward weight."""
         times = [_ts(0), _ts(60)]
@@ -832,6 +849,39 @@ class TestCombineMovingAverages:
         assert len(result) == 100
         for r in result:
             assert r["reward_weight"] == pytest.approx(0.03)
+
+    def test_three_competitions_combined_sum_to_one(self):
+        """The 2->3 split invariant: each competition's reward_weights sum to
+        SMOOTHED_SCORE_COEFFICIENT (1/3), so combining the three real labels
+        yields a total of ~1.0. Crypto miners (in both Crypto 1h and Crypto
+        24h) get their two weights summed; a commodity miner appears once.
+        """
+        third = SMOOTHED_SCORE_COEFFICIENT
+        data = {
+            "Crypto 1h": [
+                {"miner_id": 1, "miner_uid": 1, "reward_weight": third / 2},
+                {"miner_id": 2, "miner_uid": 2, "reward_weight": third / 2},
+            ],
+            "Crypto 24h": [
+                {"miner_id": 1, "miner_uid": 1, "reward_weight": third / 2},
+                {"miner_id": 2, "miner_uid": 2, "reward_weight": third / 2},
+            ],
+            "Commodities/Equities 24h": [
+                {"miner_id": 3, "miner_uid": 3, "reward_weight": third},
+            ],
+        }
+        result = combine_moving_averages(data)
+
+        total = sum(r["reward_weight"] for r in result)
+        assert total == pytest.approx(1.0, abs=1e-9)
+
+        weights = {r["miner_id"]: r["reward_weight"] for r in result}
+        # crypto miners scored in both crypto competitions -> summed
+        assert weights[1] == pytest.approx(third)
+        assert weights[2] == pytest.approx(third)
+        # commodity/equity miner appears only in its one competition
+        assert weights[3] == pytest.approx(third)
+        assert len(result) == 3
 
 
 # ===========================================================================


### PR DESCRIPTION
Layer-0 (automated tests) + Layer-2 (soak tooling) from the competition-split QA plan.

## Tests (`tests/`)
- **`test_moving_average_unit.py`**
  - `test_three_competitions_combined_sum_to_one` — `combine_moving_averages` over the three real labels (`Crypto 1h`, `Crypto 24h`, `Commodities/Equities 24h`) sums to ~1.0 (3 × `SMOOTHED_SCORE_COEFFICIENT`), with crypto miners' weights summed across the two crypto competitions. Guards the emissions-split invariant.
  - `test_com_equ_competition_config` — `compute_smoothed_score` sets the `Commodities/Equities 24h` label and scores **SPCX** (regression guard that the new asset has an `ASSET_COEFFICIENTS` entry).
- **`test_forward.py`**
  - `test_moving_average_writes_all_three_competitions` — DB-backed, **no live price fetch**: seeds `miner_scores` for all three competitions and asserts `calculate_moving_average_and_update_rewards` writes all three `prompt_name` labels to `miner_rewards` and the combined per-miner weights sum to ~1.0.

## Tooling (`scripts/`)
- **`check_competition_rewards.py`** — read-only Layer-2 soak check against the validator Postgres: per-competition `reward_weight` sums for the latest cycle (~1/3 each), recent `miner_scores` volume per `(asset, time_length)`, and recent `weights_update_history` results. Companion to `check_testnet_predictions.py`.

All green locally; `black`/`flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)