### PR TITLE
feat(validator): delete Bigtable prediction rows on Postgres soft-delete

### DIFF
--- a/scripts/backfill_bigtable_tombstone_deletes.py
+++ b/scripts/backfill_bigtable_tombstone_deletes.py
@@ -1,0 +1,94 @@
+"""One-off backfill: delete Bigtable rows for already-tombstoned predictions.
+
+The validator now deletes Bigtable rows when it soft-deletes the Postgres
+siblings (density tapering / cleanup_old_history), but rows tombstoned
+before that change keep their blobs until the per-table GC max-age. This
+script deletes those orphaned blobs.
+
+Run with the SAME environment as the validator — Postgres creds
+(POSTGRES_USER/PASSWORD/HOST/PORT/DB) and, for --execute, Bigtable
+(BIGTABLE_PROJECT, BIGTABLE_INSTANCE, BIGTABLE_TABLE_PREDICTION_LOW,
+BIGTABLE_TABLE_PREDICTION_HIGH) + GOOGLE_APPLICATION_CREDENTIALS.
+
+Dry-run by default: only counts the tombstoned rows that still carry a
+bigtable_key, per time_length. Pass --execute to actually delete.
+Idempotent — deleting an already-deleted Bigtable row is a no-op, so the
+script can be re-run after a partial failure.
+
+    python scripts/backfill_bigtable_tombstone_deletes.py
+    python scripts/backfill_bigtable_tombstone_deletes.py --execute
+"""
+
+import argparse
+from collections import defaultdict
+
+from dotenv import load_dotenv
+from sqlalchemy import text
+
+from synth.db.models import get_engine
+from synth.validator.bigtable_prediction_storage import (
+    BigtablePredictionStorage,
+)
+
+PAGE_SIZE = 10_000
+
+# Paginated by mp.id so memory stays bounded on a large backlog.
+_PAGE_SQL = text("""
+    SELECT mp.id, mp.bigtable_key, vr.time_length
+      FROM miner_predictions mp
+      JOIN validator_requests vr ON vr.id = mp.validator_requests_id
+     WHERE mp.deleted_at IS NOT NULL
+       AND mp.bigtable_key IS NOT NULL
+       AND mp.id > :last_id
+     ORDER BY mp.id
+     LIMIT :page_size
+""")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="delete Bigtable rows of tombstoned miner_predictions"
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="actually delete from Bigtable (default: dry-run, count only)",
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+    engine = get_engine()
+    storage = BigtablePredictionStorage() if args.execute else None
+
+    counts_per_time_length: dict[int, int] = defaultdict(int)
+    last_id = 0
+    while True:
+        with engine.connect() as connection:
+            rows = connection.execute(
+                _PAGE_SQL, {"last_id": last_id, "page_size": PAGE_SIZE}
+            ).all()
+        if not rows:
+            break
+        last_id = rows[-1][0]
+
+        keys_per_time_length: dict[int, list[str]] = defaultdict(list)
+        for _, bigtable_key, time_length in rows:
+            keys_per_time_length[time_length].append(bigtable_key)
+
+        for time_length, keys in keys_per_time_length.items():
+            if storage is not None:
+                storage.delete_predictions(time_length, keys)
+            counts_per_time_length[time_length] += len(keys)
+
+        total = sum(counts_per_time_length.values())
+        print(f"processed {total} rows (last id {last_id})")
+
+    action = "deleted" if args.execute else "would delete (dry-run)"
+    for time_length, count in sorted(counts_per_time_length.items()):
+        print(f"time_length={time_length}: {action} {count} bigtable rows")
+    if not counts_per_time_length:
+        print("no tombstoned rows with a bigtable_key found")
+
+
+if __name__ == "__main__":
+    main()

--- a/synth/validator/bigtable_prediction_storage.py
+++ b/synth/validator/bigtable_prediction_storage.py
@@ -283,21 +283,21 @@ class BigtablePredictionStorage:
         prompt_label = prompt_config.label_from_time_length(time_length)
         table = self._table_for_label(prompt_label)
 
-        rows = []
-        for key in keys:
-            row = table.direct_row(key)
-            row.delete()
-            rows.append(row)
-
+        # Build DirectRows per chunk (not all up front) so memory stays
+        # bounded by _DELETE_CHUNK_ROWS on large deletes.
         statuses: list = []
-        for i in range(0, len(rows), _DELETE_CHUNK_ROWS):
-            chunk = rows[i : i + _DELETE_CHUNK_ROWS]
-            statuses.extend(table.mutate_rows(chunk) or [])
+        for i in range(0, len(keys), _DELETE_CHUNK_ROWS):
+            rows = []
+            for key in keys[i : i + _DELETE_CHUNK_ROWS]:
+                row = table.direct_row(key)
+                row.delete()
+                rows.append(row)
+            statuses.extend(table.mutate_rows(rows) or [])
 
-        if len(statuses) != len(rows):
+        if len(statuses) != len(keys):
             raise RuntimeError(
                 f"bigtable delete mutate_rows returned {len(statuses)} "
-                f"statuses for {len(rows)} rows"
+                f"statuses for {len(keys)} rows"
             )
 
         failed_keys = []
@@ -315,7 +315,7 @@ class BigtablePredictionStorage:
         if failed_keys:
             raise RuntimeError(
                 f"bigtable delete mutate_rows failed for "
-                f"{len(failed_keys)}/{len(rows)} rows"
+                f"{len(failed_keys)}/{len(keys)} rows"
             )
 
     def _table_for_label(self, prompt_label: str):

--- a/synth/validator/bigtable_prediction_storage.py
+++ b/synth/validator/bigtable_prediction_storage.py
@@ -1,10 +1,13 @@
 """Bigtable storage backend for miner predictions.
 
 Each (asset, start_time, miner) is one row, value = raw float32 bytes shaped
-(num_simulations x num_timesteps). Two tables are used so retention is
-enforced by per-table GC policy: one for the `low` prompt and one for the
-`high` prompt. The table choice already encodes the prompt label, so the
-row key omits it.
+(num_simulations x num_timesteps). Two tables are used, one for the `low`
+prompt and one for the `high` prompt. The table choice already encodes the
+prompt label, so the row key omits it.
+
+Rows are deleted explicitly (best-effort) when their Postgres siblings are
+soft-deleted; the per-table GC max-age policy is the backstop for deletes
+that never land.
 
 The Postgres `miner_predictions` row stays — its `prediction` column holds a
 sentinel JSON, and `bigtable_key` holds the row key used here.
@@ -30,6 +33,11 @@ COLUMN_QUALIFIER = b"d"
 
 # Cap the bytes carried by a single mutate_rows RPC
 _MAX_MUTATE_BYTES = 100 * 1024 * 1024
+
+# Cap the entries carried by a single mutate_rows RPC when deleting.
+# Delete mutations have no payload, so the byte cap above doesn't apply;
+# the server limit is 100k entries per MutateRows call.
+_DELETE_CHUNK_ROWS = 10_000
 
 # Zero-pad miner_id so lexicographic order inside a range scan matches
 # numeric order. 6 digits cover the foreseeable miners.id space (Postgres
@@ -237,9 +245,9 @@ class BigtablePredictionStorage:
                 if isinstance(row.row_key, bytes)
                 else row.row_key
             )
-            # The range scan also surfaces rows whose Postgres siblings
-            # were soft-deleted (density tapering doesn't touch Bigtable).
-            # Filter to the keys the caller asked for.
+            # The range scan can still surface rows whose Postgres
+            # siblings were soft-deleted: deletes are best-effort and can
+            # fail or lag behind. Filter to the keys the caller asked for.
             if key not in wanted:
                 continue
             cells = row.cells.get(COLUMN_FAMILY, {}).get(COLUMN_QUALIFIER, [])
@@ -258,6 +266,57 @@ class BigtablePredictionStorage:
                 )
 
         return result
+
+    def delete_predictions(self, time_length: int, keys: list) -> None:
+        """Delete prediction rows from Bigtable by exact row key.
+
+        Called when the Postgres siblings are soft-deleted (density
+        tapering / cleanup_old_history) so the blobs don't sit as dead
+        weight until the per-table GC max-age. Best-effort from the
+        caller's perspective: raises on any unconfirmed delete so the
+        caller can log it — the GC policy remains the backstop for rows
+        whose delete never lands.
+        """
+        if not keys:
+            return
+
+        prompt_label = prompt_config.label_from_time_length(time_length)
+        table = self._table_for_label(prompt_label)
+
+        rows = []
+        for key in keys:
+            row = table.direct_row(key)
+            row.delete()
+            rows.append(row)
+
+        statuses: list = []
+        for i in range(0, len(rows), _DELETE_CHUNK_ROWS):
+            chunk = rows[i : i + _DELETE_CHUNK_ROWS]
+            statuses.extend(table.mutate_rows(chunk) or [])
+
+        if len(statuses) != len(rows):
+            raise RuntimeError(
+                f"bigtable delete mutate_rows returned {len(statuses)} "
+                f"statuses for {len(rows)} rows"
+            )
+
+        failed_keys = []
+        for key, status in zip(keys, statuses):
+            # Same contract as write_predictions: a None status means the
+            # SDK had no per-row response — treat as unconfirmed.
+            code = getattr(status, "code", None)
+            if code is None or code != 0:
+                failed_keys.append(key)
+                message = getattr(status, "message", "no status returned")
+                bt.logging.error(
+                    f"bigtable delete failed for key={key} "
+                    f"code={code} message={message}"
+                )
+        if failed_keys:
+            raise RuntimeError(
+                f"bigtable delete mutate_rows failed for "
+                f"{len(failed_keys)}/{len(rows)} rows"
+            )
 
     def _table_for_label(self, prompt_label: str):
         try:

--- a/synth/validator/miner_data_handler.py
+++ b/synth/validator/miner_data_handler.py
@@ -866,11 +866,12 @@ class MinerDataHandler:
                AND validator_requests_id NOT IN (
                    SELECT vr_id FROM latest_per_asset
                )
+            RETURNING miner_predictions.bigtable_key
             """)
         try:
             with self.engine.connect() as connection:
                 with connection.begin():
-                    connection.execute(
+                    result = connection.execute(
                         thin_sql,
                         {
                             "bucket_seconds": (
@@ -883,6 +884,17 @@ class MinerDataHandler:
                             "salt": self.thinning_salt,
                         },
                     )
+                    bigtable_keys = [
+                        key for (key,) in result if key is not None
+                    ]
+            # Postgres is committed at this point. Deleting from Bigtable
+            # after the commit means a rollback can never orphan-delete
+            # blobs; a failed Bigtable delete just leaves rows to age out
+            # via the per-table GC policy (logged by the except below).
+            if self.bigtable_storage is not None and bigtable_keys:
+                self.bigtable_storage.delete_predictions(
+                    prompt_config.time_length, bigtable_keys
+                )
         except Exception as e:
             bt.logging.exception(
                 f"in prune_redundant_predictions (got an exception): {e}"
@@ -918,8 +930,12 @@ class MinerDataHandler:
                                 "reason": "light mode",
                             },
                         )
+                        .returning(MinerPrediction.bigtable_key)
                     )
-                    connection.execute(erase_predictions_statement)
+                    erased = connection.execute(erase_predictions_statement)
+                    bigtable_keys = [
+                        key for (key,) in erased if key is not None
+                    ]
 
                     delete_scores_statement = delete(MinerScore).where(
                         MinerScore.scored_time < cutoff_date_double,
@@ -941,6 +957,14 @@ class MinerDataHandler:
                         .values(real_prices=[])
                     )
                     connection.execute(erase_validator_requests_statement)
+
+            # Same ordering as density_tapering_predictions: delete from
+            # Bigtable only once Postgres is committed; failures leave the
+            # rows to the GC backstop.
+            if self.bigtable_storage is not None and bigtable_keys:
+                self.bigtable_storage.delete_predictions(
+                    prompt_config.time_length, bigtable_keys
+                )
 
         except Exception as e:
             bt.logging.exception(

--- a/synth/validator/miner_data_handler.py
+++ b/synth/validator/miner_data_handler.py
@@ -897,7 +897,7 @@ class MinerDataHandler:
                 )
         except Exception as e:
             bt.logging.exception(
-                f"in prune_redundant_predictions (got an exception): {e}"
+                f"in density_tapering_predictions (got an exception): {e}"
             )
 
     @print_execution_time

--- a/tests/test_bigtable_prediction_storage.py
+++ b/tests/test_bigtable_prediction_storage.py
@@ -404,3 +404,106 @@ def test_start_time_to_unix_treats_naive_as_utc():
     base = bps._start_time_to_unix("2026-05-25T12:00:00")
     assert bps._start_time_to_unix("2026-05-25T12:00:00+00:00") == base
     assert bps._start_time_to_unix("2026-05-25T12:00:00") == 1779710400
+
+
+def test_delete_predictions_routes_to_low_table():
+    storage = _make_storage_with_mock_tables()
+    rows_by_key = {}
+
+    def _direct_row(key):
+        row = MagicMock(key=key)
+        rows_by_key[key] = row
+        return row
+
+    storage._tables["low"].direct_row.side_effect = _direct_row
+    storage._tables["low"].mutate_rows.side_effect = lambda chunk: [
+        MagicMock(code=0) for _ in chunk
+    ]
+
+    storage.delete_predictions(LOW_TIME_LENGTH, ["k1", "k2"])
+
+    # One DeleteFromRow mutation per key, sent to the low table only.
+    assert set(rows_by_key.keys()) == {"k1", "k2"}
+    for row in rows_by_key.values():
+        row.delete.assert_called_once_with()
+    storage._tables["low"].mutate_rows.assert_called_once()
+    storage._tables["high"].direct_row.assert_not_called()
+
+
+def test_delete_predictions_routes_to_high_table():
+    storage = _make_storage_with_mock_tables()
+    storage._tables["high"].direct_row.side_effect = lambda key: MagicMock(
+        key=key
+    )
+    storage._tables["high"].mutate_rows.side_effect = lambda chunk: [
+        MagicMock(code=0) for _ in chunk
+    ]
+
+    storage.delete_predictions(HIGH_TIME_LENGTH, ["k1"])
+
+    storage._tables["high"].mutate_rows.assert_called_once()
+    storage._tables["low"].direct_row.assert_not_called()
+
+
+def test_delete_predictions_empty_keys_is_noop():
+    storage = _make_storage_with_mock_tables()
+
+    storage.delete_predictions(LOW_TIME_LENGTH, [])
+
+    storage._tables["low"].mutate_rows.assert_not_called()
+    storage._tables["high"].mutate_rows.assert_not_called()
+
+
+def test_delete_predictions_chunks_by_row_count(monkeypatch):
+    storage = _make_storage_with_mock_tables()
+    storage._tables["low"].direct_row.side_effect = lambda key: MagicMock(
+        key=key
+    )
+    storage._tables["low"].mutate_rows.side_effect = lambda chunk: [
+        MagicMock(code=0) for _ in chunk
+    ]
+    monkeypatch.setattr(bps, "_DELETE_CHUNK_ROWS", 2)
+
+    storage.delete_predictions(LOW_TIME_LENGTH, ["k1", "k2", "k3"])
+
+    # 3 keys, 2 per chunk → 2 RPCs.
+    assert storage._tables["low"].mutate_rows.call_count == 2
+
+
+def test_delete_predictions_raises_when_any_mutate_fails():
+    storage = _make_storage_with_mock_tables()
+    storage._tables["low"].direct_row.side_effect = lambda key: MagicMock(
+        key=key
+    )
+    bad = MagicMock()
+    bad.code = 13  # any non-zero
+    bad.message = "boom"
+    storage._tables["low"].mutate_rows.return_value = [
+        MagicMock(code=0),
+        bad,
+    ]
+
+    with pytest.raises(RuntimeError):
+        storage.delete_predictions(LOW_TIME_LENGTH, ["k1", "k2"])
+
+
+def test_delete_predictions_treats_none_status_as_failure():
+    storage = _make_storage_with_mock_tables()
+    storage._tables["low"].direct_row.side_effect = lambda key: MagicMock(
+        key=key
+    )
+    storage._tables["low"].mutate_rows.return_value = [None]
+
+    with pytest.raises(RuntimeError):
+        storage.delete_predictions(LOW_TIME_LENGTH, ["k1"])
+
+
+def test_delete_predictions_raises_on_short_status_list():
+    storage = _make_storage_with_mock_tables()
+    storage._tables["low"].direct_row.side_effect = lambda key: MagicMock(
+        key=key
+    )
+    storage._tables["low"].mutate_rows.return_value = [MagicMock(code=0)]
+
+    with pytest.raises(RuntimeError, match="statuses"):
+        storage.delete_predictions(LOW_TIME_LENGTH, ["k1", "k2"])

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -620,6 +620,7 @@ def _insert_prediction(
     start_time: datetime,
     created_at: datetime,
     payload: list,
+    bigtable_key: str | None = None,
 ) -> int:
     vr_id = (
         connection.execute(
@@ -648,6 +649,7 @@ def _insert_prediction(
                 format_validation=response_validation_v2.CORRECT,
                 process_time=1.0,
                 created_at=created_at,
+                bigtable_key=bigtable_key,
             )
             .returning(MinerPrediction.id)
         )
@@ -1461,3 +1463,169 @@ def test_prune_drops_protection_once_latest_ages_past_time_length(
         )
     assert len(alive) == 1
     assert len(thinned) == 1
+
+
+class _DeleteSpyBigtable:
+    """Records delete_predictions calls; other storage methods unused."""
+
+    def __init__(self, fail: bool = False):
+        self.delete_calls: list[tuple[int, list[str]]] = []
+        self.fail = fail
+
+    def delete_predictions(self, time_length: int, keys: list):
+        self.delete_calls.append((time_length, sorted(keys)))
+        if self.fail:
+            raise RuntimeError("bigtable unavailable")
+
+
+def test_density_tapering_deletes_bigtable_rows(db_engine: Engine):
+    """Thinned rows' bigtable_keys are deleted from Bigtable; the keeper's
+    key is not. Keeper choice is a salted hash, so expectations are derived
+    from the post-run Postgres state."""
+    start = (datetime.now() - timedelta(hours=25)).replace(
+        minute=10, second=0, microsecond=0
+    )
+    with db_engine.connect() as connection:
+        with connection.begin():
+            miner_id = _insert_miner(connection, miner_uid=330)
+            mp_ids = [
+                _insert_prediction(
+                    connection,
+                    miner_id=miner_id,
+                    asset="ETH",
+                    time_length=LOW_TEST_CONFIG.time_length,
+                    start_time=start + timedelta(minutes=5 * i),
+                    created_at=start + timedelta(minutes=5 * i),
+                    payload=[[{"price": float(i)}]],
+                    bigtable_key=f"bt-key-{i}",
+                )
+                for i in range(3)
+            ]
+
+    fake = _DeleteSpyBigtable()
+    handler = MinerDataHandler(db_engine, bigtable_storage=fake)
+    handler.density_tapering_predictions(LOW_TEST_CONFIG)
+
+    with db_engine.connect() as connection:
+        alive, thinned = _split_alive_thinned(connection, mp_ids)
+        thinned_keys = sorted(
+            connection.execute(
+                select(MinerPrediction.bigtable_key).where(
+                    MinerPrediction.id.in_(thinned)
+                )
+            ).scalars()
+        )
+    assert len(alive) == 1
+    assert len(thinned) == 2
+    assert fake.delete_calls == [(LOW_TEST_CONFIG.time_length, thinned_keys)]
+
+
+def test_density_tapering_skips_bigtable_without_keys(db_engine: Engine):
+    """Rows without a bigtable_key (Postgres-backend rows) never reach
+    delete_predictions."""
+    start = (datetime.now() - timedelta(hours=25)).replace(
+        minute=10, second=0, microsecond=0
+    )
+    with db_engine.connect() as connection:
+        with connection.begin():
+            miner_id = _insert_miner(connection, miner_uid=331)
+            mp_ids = [
+                _insert_prediction(
+                    connection,
+                    miner_id=miner_id,
+                    asset="ETH",
+                    time_length=LOW_TEST_CONFIG.time_length,
+                    start_time=start + timedelta(minutes=5 * i),
+                    created_at=start + timedelta(minutes=5 * i),
+                    payload=[[{"price": float(i)}]],
+                )
+                for i in range(2)
+            ]
+
+    fake = _DeleteSpyBigtable()
+    handler = MinerDataHandler(db_engine, bigtable_storage=fake)
+    handler.density_tapering_predictions(LOW_TEST_CONFIG)
+
+    with db_engine.connect() as connection:
+        alive, thinned = _split_alive_thinned(connection, mp_ids)
+    assert len(alive) == 1
+    assert len(thinned) == 1
+    assert fake.delete_calls == []
+
+
+def test_density_tapering_bigtable_failure_keeps_tombstones(
+    db_engine: Engine,
+):
+    """A failed Bigtable delete must not roll back the Postgres
+    tombstoning — the rows are left to the GC backstop."""
+    start = (datetime.now() - timedelta(hours=25)).replace(
+        minute=10, second=0, microsecond=0
+    )
+    with db_engine.connect() as connection:
+        with connection.begin():
+            miner_id = _insert_miner(connection, miner_uid=332)
+            mp_ids = [
+                _insert_prediction(
+                    connection,
+                    miner_id=miner_id,
+                    asset="ETH",
+                    time_length=LOW_TEST_CONFIG.time_length,
+                    start_time=start + timedelta(minutes=5 * i),
+                    created_at=start + timedelta(minutes=5 * i),
+                    payload=[[{"price": float(i)}]],
+                    bigtable_key=f"bt-key-fail-{i}",
+                )
+                for i in range(2)
+            ]
+
+    fake = _DeleteSpyBigtable(fail=True)
+    handler = MinerDataHandler(db_engine, bigtable_storage=fake)
+    handler.density_tapering_predictions(LOW_TEST_CONFIG)  # no raise
+
+    with db_engine.connect() as connection:
+        alive, thinned = _split_alive_thinned(connection, mp_ids)
+    assert len(alive) == 1
+    assert len(thinned) == 1
+    assert len(fake.delete_calls) == 1
+
+
+def test_cleanup_old_history_deletes_bigtable_rows(db_engine: Engine):
+    """Rows erased by retention cleanup have their Bigtable rows deleted;
+    rows still inside the retention window are untouched."""
+    now = datetime.now()
+    old = now - timedelta(days=LOW_TEST_CONFIG.data_retention_days + 1)
+    fresh = now - timedelta(days=1)
+    with db_engine.connect() as connection:
+        with connection.begin():
+            miner_id = _insert_miner(connection, miner_uid=333)
+            old_mp = _insert_prediction(
+                connection,
+                miner_id=miner_id,
+                asset="ETH",
+                time_length=LOW_TEST_CONFIG.time_length,
+                start_time=old,
+                created_at=old,
+                payload=[[{"price": 1.0}]],
+                bigtable_key="bt-key-old",
+            )
+            fresh_mp = _insert_prediction(
+                connection,
+                miner_id=miner_id,
+                asset="ETH",
+                time_length=LOW_TEST_CONFIG.time_length,
+                start_time=fresh,
+                created_at=fresh,
+                payload=[[{"price": 2.0}]],
+                bigtable_key="bt-key-fresh",
+            )
+
+    fake = _DeleteSpyBigtable()
+    handler = MinerDataHandler(db_engine, bigtable_storage=fake)
+    handler.cleanup_old_history(LOW_TEST_CONFIG)
+
+    with db_engine.connect() as connection:
+        old_row = _fetch_prediction_state(connection, old_mp)
+        fresh_row = _fetch_prediction_state(connection, fresh_mp)
+    assert old_row.deleted_at is not None
+    assert fresh_row.deleted_at is None
+    assert fake.delete_calls == [(LOW_TEST_CONFIG.time_length, ["bt-key-old"])]


### PR DESCRIPTION
## What

When `density_tapering_predictions` or `cleanup_old_history` soft-deletes miner predictions in Postgres, the corresponding Bigtable rows are now deleted too, instead of waiting for the per-table GC max-age.

- `BigtablePredictionStorage.delete_predictions(time_length, keys)`: one `DeleteFromRow` mutation per key, sent via `mutate_rows` in count-bounded chunks; raises on any unconfirmed status (same contract as writes).
- Both soft-delete paths collect the affected `bigtable_key`s via `RETURNING` and delete them **after** the Postgres commit — a rollback can never orphan-delete blobs, and a failed Bigtable delete is only logged; those rows age out via GC as before.
- `scripts/backfill_bigtable_tombstone_deletes.py`: one-off, idempotent backfill for rows tombstoned before this change (dry-run by default, `--execute` to delete).

## Tests

- Unit tests for `delete_predictions`: table routing, chunking, failure statuses.
- Handler tests (testcontainers Postgres): thinned/erased rows' keys are deleted, keeper and in-retention rows are not, rows without a `bigtable_key` are skipped, and a failing Bigtable delete does not roll back the Postgres tombstoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)