### PR TITLE
perf(validator): vectorise response validation, redefine price rule as 8 significant digits

### DIFF
--- a/docs/miner_reference.md
+++ b/docs/miner_reference.md
@@ -633,7 +633,7 @@ where
 - the first element is the timestamp of the start time of the prompt,
 - second is the time increment of the prompt,
 - then arrays of prices, where each point must be a finite number (no `NaN`/`Infinity`, no booleans) with at most 8 significant digits — magnitude and sign don't matter, e.g. `12345678.0`, `0.00012345678` and `1.2345e20` are all valid. Otherwise, the validator will reject the submission.
-  - validation error messages: `Price format is incorrect: too many digits`, `Price format is incorrect: non-finite value`
+  - validation error messages: `Price format is incorrect: too many digits <point>`, `Price format is incorrect: non-finite value <point>`
 
 You can find the validation function (`_point_error`) here:
 

--- a/docs/miner_reference.md
+++ b/docs/miner_reference.md
@@ -632,12 +632,12 @@ where
 
 - the first element is the timestamp of the start time of the prompt,
 - second is the time increment of the prompt,
-- then arrays of prices with no more than 8 digits per point. Otherwise, the validator will reject the submission.
-  - validation error message: `Price format is incorrect: too many digits`
+- then arrays of prices, where each point must be a finite number (no `NaN`/`Infinity`, no booleans) with at most 8 significant digits — magnitude and sign don't matter, e.g. `12345678.0`, `0.00012345678` and `1.2345e20` are all valid. Otherwise, the validator will reject the submission.
+  - validation error messages: `Price format is incorrect: too many digits`, `Price format is incorrect: non-finite value`
 
-You can find the validation function here:
+You can find the validation function (`_point_error`) here:
 
-[response_validation_v2.py#L51](https://github.com/synthdataco/synth-subnet/blob/main/synth/validator/response_validation_v2.py#L51)
+[response_validation_v2.py](https://github.com/synthdataco/synth-subnet/blob/main/synth/validator/response_validation_v2.py)
 
 And an example of the prompt parameters here:
 

--- a/synth/validator/response_validation_v2.py
+++ b/synth/validator/response_validation_v2.py
@@ -1,31 +1,72 @@
 from datetime import datetime
+import math
 import typing
 
+import numpy as np
 
 from synth.simulation_input import SimulationInput
 
 CORRECT = "CORRECT"
 
+MAX_SIGNIFICANT_DIGITS = 8
 
-def validate_path(
-    path: typing.List[float], expected_time_points: int
-) -> typing.Optional[str]:
-    if not isinstance(path, list):
-        return f"Path format is incorrect: expected list, got {type(path)}"
 
-    # check the number of time points
-    if len(path) != expected_time_points:
-        return f"Number of time points is incorrect: expected {expected_time_points}, got {len(path)}"
+def _point_error(point) -> typing.Optional[str]:
+    """The rule, per point: an int or float (bools excluded), finite, with
+    at most MAX_SIGNIFICANT_DIGITS significant digits — i.e. the value
+    round-trips through its 8-significant-digit decimal form."""
+    if isinstance(point, bool) or not isinstance(point, (int, float)):
+        return f"Price format is incorrect: expected int or float, got {type(point)}"
 
-    for point in path:
-        # check the price format
-        if not isinstance(point, (int, float)):
-            return f"Price format is incorrect: expected int or float, got {type(point)}"
+    try:
+        value = float(point)
+    except OverflowError:  # int beyond float64 range
+        return f"Price format is incorrect: too many digits {point}"
 
-        if len(str(point).replace(".", "")) > 8:
-            return f"Price format is incorrect: too many digits {point}"
+    if not math.isfinite(value):
+        return f"Price format is incorrect: non-finite value {point}"
+
+    if float(f"{value:.{MAX_SIGNIFICANT_DIGITS - 1}e}") != value:
+        return f"Price format is incorrect: too many digits {point}"
 
     return None
+
+
+def _sig_digits_pass_mask(matrix: np.ndarray) -> np.ndarray:
+    """Vectorised _point_error: True marks points proven valid; False only
+    means "recheck with the exact scalar rule".
+
+    A point is proven by scaling it to an integer mantissa of at most
+    8 digits and checking the scaling round-trips exactly. Only positive
+    powers of ten are used (negative ones are not exact in float64), so
+    the equality is exact — and the [1e-14, 1e14] band plus the mantissa
+    cap keep it exact even if log10 is off by one at a decade boundary.
+    """
+    if matrix.dtype.kind != "f":
+        matrix = matrix.astype(np.float64)
+
+    absx = np.abs(matrix)
+    provable = (
+        np.isfinite(matrix)
+        & (absx >= 1e-14)
+        & (absx <= 1e14)
+        # 0 and 1 may be bools coerced by np.asarray — leave them to the
+        # scalar rule, which sees the original object's type.
+        & (matrix != 0.0)
+        & (matrix != 1.0)
+    )
+
+    x = np.where(provable, matrix, 1.0)  # neutral filler for the math below
+    exponent = np.floor(np.log10(np.abs(x))).astype(np.int64)
+    shift = (MAX_SIGNIFICANT_DIGITS - 1) - exponent
+
+    up = np.power(10.0, np.maximum(shift, 0))
+    down = np.power(10.0, np.maximum(-shift, 0))
+    mantissa = np.round(x * up / down)
+
+    fits_cap = np.abs(mantissa) < 10**MAX_SIGNIFICANT_DIGITS
+    round_trips = mantissa * down / up == x
+    return np.asarray(provable & fits_cap & round_trips)
 
 
 def validate_response_type(response) -> typing.Optional[str]:
@@ -91,9 +132,51 @@ def validate_responses(
     expected_time_points = (
         simulation_input.time_length // simulation_input.time_increment + 1
     )
-    for path in all_paths:
-        error_message = validate_path(path, expected_time_points)
-        if error_message:
-            return error_message
+
+    error_message = _validate_all_paths(all_paths, expected_time_points)
+    if error_message:
+        return error_message
 
     return CORRECT
+
+
+def _validate_all_paths(
+    all_paths, expected_time_points: int
+) -> typing.Optional[str]:
+    """Validate every path's shape and points, first offender wins.
+
+    Points are bulk-validated in one NumPy pass; anything not provably
+    valid is re-checked with the exact scalar rule in original scan order.
+    """
+    for path in all_paths:
+        if not isinstance(path, list):
+            return f"Path format is incorrect: expected list, got {type(path)}"
+        if len(path) != expected_time_points:
+            return f"Number of time points is incorrect: expected {expected_time_points}, got {len(path)}"
+
+    try:
+        matrix = np.asarray(all_paths)
+    except ValueError:  # ragged nesting (a point that is a sequence)
+        matrix = None
+
+    if matrix is None or matrix.ndim != 2 or matrix.dtype.kind not in "iuf":
+        return _validate_points_exact(all_paths)
+
+    proven = _sig_digits_pass_mask(matrix)
+    if proven.all():
+        return None
+
+    for i, j in zip(*np.nonzero(~proven)):
+        error_message = _point_error(all_paths[i][j])
+        if error_message:
+            return error_message
+    return None
+
+
+def _validate_points_exact(all_paths) -> typing.Optional[str]:
+    for path in all_paths:
+        for point in path:
+            error_message = _point_error(point)
+            if error_message:
+                return error_message
+    return None

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+import math
+
 from synth.simulation_input import SimulationInput
 from synth.validator.response_validation_v2 import validate_responses, CORRECT
 
@@ -252,3 +254,174 @@ def test_validate_responses_correct_2():
 
     result = validate_responses(response, simulation_input, process_time_str)
     assert result == CORRECT
+
+
+# --- vectorised significant-digit rule parity ----------------------------
+#
+# validate_responses proves most points valid in one NumPy pass and falls
+# back to the exact scalar rule for the rest. These tests pin the combined
+# result against the scalar rule, restated verbatim below as the oracle,
+# on values chosen to stress every boundary of the vectorised proof.
+
+
+def _reference_point_verdict(point):
+    """The per-point rule, restated verbatim as the oracle: int/float
+    (bools excluded), finite, at most 8 significant digits."""
+    if isinstance(point, bool) or not isinstance(point, (int, float)):
+        return f"Price format is incorrect: expected int or float, got {type(point)}"
+    try:
+        value = float(point)
+    except OverflowError:
+        return f"Price format is incorrect: too many digits {point}"
+    if not math.isfinite(value):
+        return f"Price format is incorrect: non-finite value {point}"
+    if float(f"{value:.7e}") != value:
+        return f"Price format is incorrect: too many digits {point}"
+    return None
+
+
+_DIGIT_RULE_EDGE_CASES = [
+    # around the 8-significant-digit budget
+    123.45678,  # 8 sig digits -> valid
+    123.456789,  # 9 sig digits -> invalid
+    1234567.8,  # valid
+    9999999.5,  # valid
+    9999999.25,  # 9 sig digits -> invalid
+    12345678.0,  # 8 sig digits -> valid (trailing .0 is not significant)
+    10000000.0,  # 1 sig digit -> valid
+    1.0,
+    0.5,
+    # magnitude does not matter, only significant digits
+    0.0001234,
+    0.00012345678,  # 8 sig digits -> valid
+    0.000123456789,  # 9 sig digits -> invalid
+    1e-05,
+    1.2345e-05,
+    1.23456789e-05,  # 9 sig digits -> invalid
+    1e16,
+    1.2345e20,
+    1.23456789e20,  # 9 sig digits -> invalid
+    # ints follow the same rule, evaluated on their float value
+    12345678,  # valid
+    123456789,  # 9 sig digits -> invalid
+    99999999,
+    100000000,  # 1 sig digit -> valid
+    0,
+    # the sign is not a digit
+    -123.45,
+    -1234567.8,  # valid
+    -123.456789,  # invalid
+    -99999999,
+    # non-finite values are rejected
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    # float artefacts and extremes (outside the provable band -> fallback)
+    0.1 + 0.2,  # 0.30000000000000004 -> invalid
+    2**53 + 1.0,  # 16 sig digits -> invalid
+    5e-324,
+    1e-20,  # 1 sig digit -> valid, below the provable band
+    1e20,  # 1 sig digit -> valid, above the provable band
+    10**400,  # int beyond float64 range -> rejected, must not crash
+]
+
+
+def _single_path_response(points):
+    simulation_input = SimulationInput(
+        start_time=start_time.isoformat(),
+        num_simulations=1,
+        time_length=len(points) - 1,
+        time_increment=time_increment,
+    )
+    response = (int(start_time.timestamp()), time_increment, list(points))
+    return response, simulation_input
+
+
+def test_digit_rule_matches_reference_on_edge_cases():
+    for value in _DIGIT_RULE_EDGE_CASES:
+        response, simulation_input = _single_path_response(
+            [value, 123.45, 123.45]
+        )
+        expected = _reference_point_verdict(value) or CORRECT
+        result = validate_responses(response, simulation_input, "0")
+        assert (
+            result == expected
+        ), f"value {value!r}: expected {expected!r}, got {result!r}"
+
+
+def test_first_offending_point_is_reported():
+    # 1e-20 is valid but below the mask's provable band; the offender
+    # after it must still be the one reported, in original scan order.
+    response, simulation_input = _single_path_response(
+        [1e-20, 123.456789, 999.9999999]
+    )
+    result = validate_responses(response, simulation_input, "0")
+    assert result == "Price format is incorrect: too many digits 123.456789"
+
+
+def test_non_finite_points_are_rejected():
+    response, simulation_input = _single_path_response(
+        [123.45, float("nan"), 123.45]
+    )
+    result = validate_responses(response, simulation_input, "0")
+    assert result == "Price format is incorrect: non-finite value nan"
+
+
+def test_non_numeric_point_in_mixed_paths():
+    simulation_input = SimulationInput(
+        start_time=start_time.isoformat(),
+        num_simulations=2,
+        time_length=2,
+        time_increment=time_increment,
+    )
+    response = (
+        int(start_time.timestamp()),
+        time_increment,
+        [123.45, 123.45, 123.45],
+        [123.45, "123.45", 123.45],
+    )
+    result = validate_responses(response, simulation_input, "0")
+    assert (
+        result
+        == "Price format is incorrect: expected int or float, got <class 'str'>"
+    )
+
+
+def test_point_that_is_a_list_is_rejected():
+    # Equal-length nested lists coerce to a 3-D numeric array; the type
+    # error must still be reported per point.
+    response, simulation_input = _single_path_response(
+        [[1.0, 2.0], [3.0, 4.0]]
+    )
+    result = validate_responses(response, simulation_input, "0")
+    assert (
+        result
+        == "Price format is incorrect: expected int or float, got <class 'list'>"
+    )
+
+
+def test_bool_points_are_rejected():
+    response, simulation_input = _single_path_response([True, False, True])
+    result = validate_responses(response, simulation_input, "0")
+    assert (
+        result
+        == "Price format is incorrect: expected int or float, got <class 'bool'>"
+    )
+
+
+def test_bool_hidden_among_floats_is_rejected():
+    # np.asarray coerces True to 1.0 in a float path; the mask must not
+    # prove values 0/1 so the original bool reaches the exact type check.
+    response, simulation_input = _single_path_response([123.45, True, 123.45])
+    result = validate_responses(response, simulation_input, "0")
+    assert (
+        result
+        == "Price format is incorrect: expected int or float, got <class 'bool'>"
+    )
+
+
+def test_prices_zero_and_one_are_still_valid():
+    # 0/1 are unprovable by the mask (possible coerced bools) but real
+    # ints/floats of those values must still validate via the fallback.
+    response, simulation_input = _single_path_response([1.0, 0.0, 1, 0])
+    assert validate_responses(response, simulation_input, "0") == CORRECT


### PR DESCRIPTION
Closes #256

## What

The per-point validation loop in `validate_responses` walked ~289k points per miner in pure Python (~90 ms/miner, ~21 s per 240-miner cycle) — the gap between the dendrite forward returning and `save_responses` starting. Points are now bulk-validated in one NumPy pass: **~12 ms/miner, ~3 s per cycle (7–8×)**. The residual cost is the unavoidable list→ndarray conversion.

## Rule change (miner-facing)

The historical check `len(str(x).replace('.', '')) > 8` was an implementation artifact of Python's shortest-repr formatting (leading zeros, trailing `.0`, sign and exponent characters all counted). The intended rule is now stated directly — a price point must be:

- an `int` or `float` (**bools rejected** — subclass accident, never a price),
- **finite** (`NaN`/`Infinity` rejected — they previously slipped through because `str(nan)` is short),
- at most **8 significant digits**: `float(f"{x:.7e}") == x`. Magnitude and sign are irrelevant.

Net effect: **looser on real prices** (`12345678.0`, `0.00012345678`, `-1234567.8`, `1.2345e20` are now valid), stricter only on bools and non-finite values. `docs/miner_reference.md` updated accordingly.

## Design

`_point_error` is the rule, scalar and readable. `_sig_digits_pass_mask` is its vectorised form and deliberately **one-sided**: `True` marks points *proven* valid (exact power-of-ten scaling within `[1e-14, 1e14]`, integer-mantissa round-trip, both exact in float64); anything unproven is re-checked with the scalar rule on the original objects in original scan order. This keeps error messages and first-offender reporting intact, catches bools that `np.asarray` silently coerces to 0/1 (those values are never proven), and means correctness never depends on the NumPy path being complete — only speed does. Non-numeric/ragged/3-D content falls back entirely to the scalar path. Ints beyond float64 range are rejected cleanly instead of raising `OverflowError`.

## Verification

- 20 unit tests: a 35-value edge-case table pinned against the canonical rule (decade boundaries, provable-band edges, non-finite, huge ints, bool coercion, 0/1 prices), first-offender ordering, mixed-type paths.
- Fuzz: 0 mismatches vs the scalar rule on ~20k adversarial values across 24 orders of magnitude + 300 mixed-type matrices.
- Micro-benchmark: 1000×289-point response, 87 ms → 12 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)