### PR TITLE
feat(validator): remove p90 cap on prompt scores, fill misses with p95

### DIFF
--- a/synth/validator/miner_data_handler.py
+++ b/synth/validator/miner_data_handler.py
@@ -324,7 +324,7 @@ class MinerDataHandler:
                                 ],
                                 "score_details_v3": {
                                     "total_crps": row["total_crps"],
-                                    "percentile90": row["percentile90"],
+                                    "percentile95": row["percentile95"],
                                     "lowest_score": row["lowest_score"],
                                     "prompt_score_v3": row["prompt_score_v3"],
                                     "crps_data": row["crps_data"],
@@ -682,8 +682,13 @@ class MinerDataHandler:
                         ms.prompt_score_v3,
                         ms.scored_time,
                         vr.asset,
-                        first_value((ms.score_details_v3->>'percentile90')::float)
-                            OVER (PARTITION BY ms.scored_time ORDER BY ms.id) AS percentile90,
+                        -- percentile90 fallback: rows written before the
+                        -- p95-on-miss change; drop it once those are older
+                        -- than the largest window_days.
+                        first_value(COALESCE(
+                                (ms.score_details_v3->>'percentile95')::float,
+                                (ms.score_details_v3->>'percentile90')::float))
+                            OVER (PARTITION BY ms.scored_time ORDER BY ms.id) AS percentile95,
                         first_value((ms.score_details_v3->>'lowest_score')::float)
                             OVER (PARTITION BY ms.scored_time ORDER BY ms.id) AS lowest_score
                     FROM miner_scores ms

--- a/synth/validator/moving_average.py
+++ b/synth/validator/moving_average.py
@@ -38,7 +38,7 @@ def prepare_df_for_moving_average(df):
     """Prepare miner scores for moving average computation.
 
     For miners that joined after the earliest scored_time in the window,
-    backfills missing earlier timestamps with the worst score (percentile90 - lowest_score)
+    backfills missing earlier timestamps with the worst score (percentile95 - lowest_score)
     so they are not unfairly advantaged by having fewer data points.
 
     Miners present from the start keep only their real scores (no backfill).
@@ -54,11 +54,11 @@ def prepare_df_for_moving_average(df):
     global_score_asset_mapping = {}
     for t in all_times:
         sample = df.loc[df["scored_time"] == t].iloc[0]
-        p90 = sample.get("percentile90")
+        p95 = sample.get("percentile95")
         low = sample.get("lowest_score")
-        if p90 is None or low is None:
+        if p95 is None or low is None:
             continue
-        global_worst_score_mapping[t] = p90 - low
+        global_worst_score_mapping[t] = p95 - low
         global_score_asset_mapping[t] = sample["asset"]
 
     # Identify new miners (first appearance after the window start)

--- a/synth/validator/reward.py
+++ b/synth/validator/reward.py
@@ -201,7 +201,7 @@ def _build_detailed_info(
     miner_prediction_format_list: list,
     miner_prediction_id_list: list,
     miner_prediction_process_time: list,
-    percentile90: float,
+    percentile95: float,
     lowest_score: float,
 ) -> list[dict]:
     """Build detailed information dict from processing results."""
@@ -209,7 +209,7 @@ def _build_detailed_info(
         {
             "miner_uid": pred.miner_uid,
             "prompt_score_v3": float(prompt_score),
-            "percentile90": float(percentile90),
+            "percentile95": float(percentile95),
             "lowest_score": float(lowest_score),
             "miner_prediction_id": prediction_id,
             "format_validation": format,
@@ -341,7 +341,7 @@ def get_rewards_multiprocess(
         miner_prediction_process_time.append(process_time)
 
     score_values = np.array(scores)
-    prompt_scores, percentile90, lowest_score = compute_prompt_scores(
+    prompt_scores, percentile95, lowest_score = compute_prompt_scores(
         score_values
     )
 
@@ -359,7 +359,7 @@ def get_rewards_multiprocess(
         miner_prediction_format_list,
         miner_prediction_id_list,
         miner_prediction_process_time,
-        percentile90,
+        percentile95,
         lowest_score,
     )
 
@@ -371,11 +371,11 @@ def compute_prompt_scores(score_values: np.ndarray):
     if np.all(score_values == -1):
         return None, 0, 0
     score_values_valid = score_values[score_values != -1]
-    percentile90 = np.percentile(score_values_valid, 90)
-    capped_scores = np.minimum(score_values, percentile90)
-    capped_scores = np.where(score_values == -1, percentile90, capped_scores)
-    lowest_score = np.min(capped_scores)
-    return capped_scores - lowest_score, percentile90, lowest_score
+    percentile95 = np.percentile(score_values_valid, 95)
+    # Valid scores are not capped; only missed responses (-1) are filled.
+    filled_scores = np.where(score_values == -1, percentile95, score_values)
+    lowest_score = np.min(filled_scores)
+    return filled_scores - lowest_score, percentile95, lowest_score
 
 
 def compute_softmax(score_values: np.ndarray, beta: float) -> np.ndarray:

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -386,7 +386,7 @@ def _seed_competition_scores(engine, comp, miner_ids, scores, scored_time):
                         prompt_score_v3=score,
                         score_details={},
                         score_details_v3={
-                            "percentile90": 0.01,
+                            "percentile95": 0.01,
                             "lowest_score": 0.0,
                         },
                     )

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -417,16 +417,14 @@ def test_set_get_scores(db_engine: Engine):
     with db_engine.connect() as connection:
         with connection.begin():
             connection.execute(
-                text(
-                    """
+                text("""
                     UPDATE miner_scores
                     SET score_details_v3 = (score_details_v3 - 'percentile95')
                         || jsonb_build_object(
                             'percentile90',
                             score_details_v3->'percentile95')
                     WHERE scored_time = :scored_time
-                    """
-                ),
+                    """),
                 {"scored_time": scored_time},
             )
 

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 
 import pytest
-from sqlalchemy import Engine, select, delete
+from sqlalchemy import Engine, select, delete, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -406,7 +406,33 @@ def test_set_get_scores(db_engine: Engine):
         asset_list=["BTC"],
     )
 
-    print("miner_scores_df", miner_scores_df)
+    assert not miner_scores_df.empty
+    assert miner_scores_df["percentile95"].notna().all()
+    expected_percentile95 = detailed_info[0]["percentile95"]
+    assert (miner_scores_df["percentile95"] == expected_percentile95).all()
+
+    # Transition regression: rows written before the p95-on-miss change
+    # carry the old 'percentile90' JSON key; the COALESCE fallback in
+    # get_miner_scores must still surface them as percentile95.
+    with db_engine.connect() as connection:
+        with connection.begin():
+            connection.execute(text("""
+                    UPDATE miner_scores
+                    SET score_details_v3 = (score_details_v3 - 'percentile95')
+                        || jsonb_build_object(
+                            'percentile90',
+                            score_details_v3->'percentile95')
+                    """))
+
+    old_key_df = handler.get_miner_scores(
+        scored_time=scored_time,
+        window_days=4,
+        time_length=86400,
+        asset_list=["BTC"],
+    )
+
+    assert not old_key_df.empty
+    assert (old_key_df["percentile95"] == expected_percentile95).all()
 
 
 def test_insert_new_miners(db_engine: Engine):
@@ -509,7 +535,7 @@ def test_set_miner_scores_upsert_preserves_individual_values(
                 "miner_uid": i,
                 "miner_prediction_id": pred.id,
                 "total_crps": scores[i % len(scores)],
-                "percentile90": 1.0,
+                "percentile95": 1.0,
                 "lowest_score": 0.01,
                 "prompt_score_v3": scores[i % len(scores)],
                 "crps_data": [{"crps": scores[i % len(scores)]}],
@@ -531,7 +557,7 @@ def test_set_miner_scores_upsert_preserves_individual_values(
                 "miner_uid": i,
                 "miner_prediction_id": pred.id,
                 "total_crps": updated_scores[i % len(updated_scores)],
-                "percentile90": 2.0,
+                "percentile95": 2.0,
                 "lowest_score": 0.02,
                 "prompt_score_v3": updated_scores[i % len(updated_scores)],
                 "crps_data": [

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -416,13 +416,19 @@ def test_set_get_scores(db_engine: Engine):
     # get_miner_scores must still surface them as percentile95.
     with db_engine.connect() as connection:
         with connection.begin():
-            connection.execute(text("""
+            connection.execute(
+                text(
+                    """
                     UPDATE miner_scores
                     SET score_details_v3 = (score_details_v3 - 'percentile95')
                         || jsonb_build_object(
                             'percentile90',
                             score_details_v3->'percentile95')
-                    """))
+                    WHERE scored_time = :scored_time
+                    """
+                ),
+                {"scored_time": scored_time},
+            )
 
     old_key_df = handler.get_miner_scores(
         scored_time=scored_time,

--- a/tests/test_moving_average_unit.py
+++ b/tests/test_moving_average_unit.py
@@ -925,7 +925,7 @@ class TestRealisticData:
         rows = []
         for ti, t in enumerate(times):
             asset = assets[ti % len(assets)]
-            p90 = rng.uniform(0.008, 0.015)
+            p95 = rng.uniform(0.008, 0.015)
             low = 0.0
             for mi in range(n_miners):
                 # ~0.5% chance of missing (99.5% fill rate)
@@ -943,7 +943,7 @@ class TestRealisticData:
                         "prompt_score_v3": score,
                         "scored_time": t,
                         "asset": asset,
-                        "percentile95": p90,
+                        "percentile95": p95,
                         "lowest_score": low,
                     }
                 )
@@ -1129,7 +1129,7 @@ class TestRealisticData:
         miner999 = prepared[prepared["miner_id"] == 999]
         assert len(miner999) > 1  # more than just the real row
 
-        # Backfilled scores should be worst score (p90 - lowest)
+        # Backfilled scores should be worst score (p95 - lowest)
         backfilled = miner999[miner999["scored_time"] < last_time]
         assert len(backfilled) > 0
         for _, row in backfilled.iterrows():

--- a/tests/test_moving_average_unit.py
+++ b/tests/test_moving_average_unit.py
@@ -47,7 +47,7 @@ def _make_scores_df(
     times: list[datetime],
     assets: list[str] | None = None,
     scores: list[float] | None = None,
-    percentile90: float = 0.01,
+    percentile95: float = 0.01,
     lowest_score: float = 0.0,
     sparse_entries: list[tuple[int, int]] | None = None,
 ) -> pd.DataFrame:
@@ -69,7 +69,7 @@ def _make_scores_df(
                     "prompt_score_v3": score,
                     "scored_time": t,
                     "asset": asset,
-                    "percentile90": percentile90,
+                    "percentile95": percentile95,
                     "lowest_score": lowest_score,
                 }
             )
@@ -84,7 +84,7 @@ def _make_scores_df(
                         "prompt_score_v3": score,
                         "scored_time": t,
                         "asset": asset,
-                        "percentile90": percentile90,
+                        "percentile95": percentile95,
                         "lowest_score": lowest_score,
                     }
                 )
@@ -155,7 +155,7 @@ class TestPrepareDfForMovingAverage:
         miner2 = result[result["miner_id"] == 2].sort_values("scored_time")
         assert len(miner2) == 3  # present at all 3 times now
 
-        # Backfilled scores should be percentile90 - lowest_score = 0.01 - 0.0 = 0.01
+        # Backfilled scores should be percentile95 - lowest_score = 0.01 - 0.0 = 0.01
         backfilled = miner2[miner2["scored_time"] < _ts(120)]
         assert len(backfilled) == 2
         for _, row in backfilled.iterrows():
@@ -234,7 +234,7 @@ class TestPrepareDfForMovingAverage:
                 "prompt_score_v3": 0.01,
                 "scored_time": t,
                 "asset": "BTC",
-                "percentile90": 0.02,
+                "percentile95": 0.02,
                 "lowest_score": 0.0,
             },
             {
@@ -242,7 +242,7 @@ class TestPrepareDfForMovingAverage:
                 "prompt_score_v3": 0.02,
                 "scored_time": t,
                 "asset": "ETH",
-                "percentile90": 0.02,
+                "percentile95": 0.02,
                 "lowest_score": 0.0,
             },
         ]
@@ -274,7 +274,7 @@ class TestPrepareDfForMovingAverage:
         assert miner2_at_t1.iloc[0]["prompt_score_v3"] == pytest.approx(0.003)
 
     def test_none_percentile_skips_backfill(self):
-        """If percentile90 or lowest_score is None, that time is skipped for backfill."""
+        """If percentile95 or lowest_score is None, that time is skipped for backfill."""
         times = [_ts(0), _ts(60)]
         miner_ids = [1, 2]
         entries = [(0, 0), (0, 1), (1, 1)]
@@ -285,8 +285,8 @@ class TestPrepareDfForMovingAverage:
             scores=[0.005],
             sparse_entries=entries,
         )
-        # Set percentile90 to None for t=0
-        df.loc[df["scored_time"] == times[0], "percentile90"] = None
+        # Set percentile95 to None for t=0
+        df.loc[df["scored_time"] == times[0], "percentile95"] = None
 
         result = prepare_df_for_moving_average(df)
         miner2_backfilled = result[
@@ -399,7 +399,7 @@ class TestComputeSmoothedScore:
                     "prompt_score_v3": score_vals[ti],
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -409,7 +409,7 @@ class TestComputeSmoothedScore:
                     "prompt_score_v3": 0.003,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -488,7 +488,7 @@ class TestComputeSmoothedScore:
                     "prompt_score_v3": 0.001,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -498,7 +498,7 @@ class TestComputeSmoothedScore:
                     "prompt_score_v3": 0.009,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -577,7 +577,7 @@ class TestComputeSmoothedScore:
                 "prompt_score_v3": 0.01,
                 "scored_time": t,
                 "asset": "BTC",
-                "percentile90": 0.02,
+                "percentile95": 0.02,
                 "lowest_score": 0.0,
             },
             {
@@ -585,7 +585,7 @@ class TestComputeSmoothedScore:
                 "prompt_score_v3": 0.01,
                 "scored_time": t,
                 "asset": "XAU",
-                "percentile90": 0.02,
+                "percentile95": 0.02,
                 "lowest_score": 0.0,
             },
         ]
@@ -644,7 +644,7 @@ class TestNumericalEquivalence:
                         "prompt_score_v3": 0.001 * mid,
                         "scored_time": t,
                         "asset": "BTC",
-                        "percentile90": 0.01,
+                        "percentile95": 0.01,
                         "lowest_score": 0.0,
                     }
                 )
@@ -681,7 +681,7 @@ class TestNumericalEquivalence:
                         "prompt_score_v3": 0.002 * mid + 0.001 * ti,
                         "scored_time": t,
                         "asset": assets[ti],
-                        "percentile90": 0.02,
+                        "percentile95": 0.02,
                         "lowest_score": 0.0,
                     }
                 )
@@ -735,7 +735,7 @@ class TestNumericalEquivalence:
                         "prompt_score_v3": min(score, 0.15),
                         "scored_time": t,
                         "asset": asset,
-                        "percentile90": 0.01,
+                        "percentile95": 0.01,
                         "lowest_score": 0.0,
                     }
                 )
@@ -943,7 +943,7 @@ class TestRealisticData:
                         "prompt_score_v3": score,
                         "scored_time": t,
                         "asset": asset,
-                        "percentile90": p90,
+                        "percentile95": p90,
                         "lowest_score": low,
                     }
                 )
@@ -1003,7 +1003,7 @@ class TestRealisticData:
                     "prompt_score_v3": 0.0,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -1014,7 +1014,7 @@ class TestRealisticData:
                     "prompt_score_v3": 0.005,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -1025,7 +1025,7 @@ class TestRealisticData:
                     "prompt_score_v3": 0.01,
                     "scored_time": t,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             )
@@ -1082,7 +1082,7 @@ class TestRealisticData:
                     "prompt_score_v3": 0.01,
                     "scored_time": _ts(i * 60),
                     "asset": asset,
-                    "percentile90": 0.02,
+                    "percentile95": 0.02,
                     "lowest_score": 0.0,
                 }
             )
@@ -1113,7 +1113,7 @@ class TestRealisticData:
                     "prompt_score_v3": 0.003,
                     "scored_time": last_time,
                     "asset": "BTC",
-                    "percentile90": 0.01,
+                    "percentile95": 0.01,
                     "lowest_score": 0.0,
                 }
             ]
@@ -1151,7 +1151,7 @@ class TestRealisticData:
 
     def test_existing_test_csv_compatible(self):
         """Run prepare + compute on the real cutoff_data_4_days.csv shape."""
-        # Simulate the CSV shape: no percentile90/lowest_score columns
+        # Simulate the CSV shape: no percentile95/lowest_score columns
         # (they get added by get_miner_scores after the merge)
         import os
 
@@ -1165,9 +1165,9 @@ class TestRealisticData:
         df = pd.read_csv(csv_path)
         df["scored_time"] = pd.to_datetime(df["scored_time"])
 
-        # The real CSV doesn't have percentile90/lowest_score — add them
+        # The real CSV doesn't have percentile95/lowest_score — add them
         # to simulate what get_miner_scores returns
-        df["percentile90"] = 0.01
+        df["percentile95"] = 0.01
         df["lowest_score"] = 0.0
 
         prepared = prepare_df_for_moving_average(df)

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -45,13 +45,15 @@ def test_compute_softmax_2():
 
 def test_compute_prompt_scores():
     crps_scores = np.array([1000, 1500, 2000, -1])
-    expected_prompt_scores = np.array([0, 500, 900, 900])
+    # Valid scores are not capped; the miss (-1) is filled with the 95th
+    # percentile of the valid scores (1950), then shifted by the minimum.
+    expected_prompt_scores = np.array([0, 500, 1000, 950])
 
-    actual_score, percentile90, lowest_score = compute_prompt_scores(
+    actual_score, percentile95, lowest_score = compute_prompt_scores(
         crps_scores
     )
 
-    assert percentile90 == 1900.0
+    assert percentile95 == 1950.0
     assert lowest_score == 1000
     assert np.array_equal(actual_score, expected_prompt_scores)
 
@@ -62,11 +64,11 @@ def test_compute_prompt_scores_only_one_miner():
         [0, 0, 0, 0]
     )  # TODO: not ideal but it's the current behavior
 
-    actual_score, percentile90, lowest_score = compute_prompt_scores(
+    actual_score, percentile95, lowest_score = compute_prompt_scores(
         crps_scores
     )
 
-    assert percentile90 == 1000
+    assert percentile95 == 1000
     assert lowest_score == 1000
     assert np.array_equal(actual_score, expected_prompt_scores)
 
@@ -94,21 +96,25 @@ def test_get_rewards(db_engine):
 
     assert prompt_scores is not None
 
-    percentile90 = detailed_info[0]["percentile90"]
+    percentile95 = detailed_info[0]["percentile95"]
 
-    # find the lowest crps value
-    crps_values = [item["total_crps"] for item in detailed_info]
-    lowest_crps = float("inf")
-    for crps in crps_values:
-        # -1 is an invalid prediction
-        if crps < lowest_crps and crps != -1:
-            lowest_crps = crps
+    # find the lowest and highest valid crps values (-1 is invalid)
+    valid_crps = [
+        item["total_crps"]
+        for item in detailed_info
+        if item["total_crps"] != -1
+    ]
+    lowest_crps = min(valid_crps)
+    highest_crps = max(valid_crps)
 
     assert len(prompt_scores) == len(miner_uids)
     assert min(prompt_scores) == 0
 
-    # the max score is the percentile90 - lowest_crps
-    assert max(prompt_scores) == percentile90 - lowest_crps
+    # valid scores are uncapped: the max score is the highest valid crps
+    # minus the lowest (misses are filled with percentile95, which never
+    # exceeds the highest valid crps)
+    assert max(prompt_scores) == highest_crps - lowest_crps
+    assert percentile95 <= highest_crps
 
     assert detailed_info[0]["miner_uid"] == miner_uids[0]
     crps_data = detailed_info[0]["crps_data"]


### PR DESCRIPTION
## What

`compute_prompt_scores` previously capped every valid CRPS score at the 90th percentile and filled missed responses (-1) with that same value. New behavior:

- valid scores flow **uncapped**,
- misses are filled with the **95th percentile** of the valid scores,
- the min-shift is unchanged.

## Persistence / transition

The percentile is a JSONB key inside `miner_scores.score_details_v3` (not a column — no migration). New rows write `percentile95`; `get_miner_scores` reads `COALESCE(->>'percentile95', ->>'percentile90')` so the moving-average window keeps working over pre-change rows. The fallback (and its regression test, which rewrites a stored row back to the old key and re-reads) can be dropped once pre-change rows are older than the largest `window_days` (10 d). Until then the new-miner backfill worst-score (`percentile95 - lowest_score`) mixes p90- and p95-derived values — self-heals.

No live external reader consumes the key (dashboards/backends read `prompt_score_v3`/`total_crps` only).

## Deliberately out of scope

The removed cap incidentally clamped `+inf` CRPS from extreme-but-valid predictions; `_crps_worker` still sanitizes NaN only. Tracked as a follow-up (non-finite CRPS → treat as miss).

## Tests

- `test_compute_prompt_scores`: `[1000, 1500, 2000, -1]` → scores `[0, 500, 1000, 950]`, p95 = 1950 (no cap: 2000 survives).
- `test_get_rewards`: new invariant — max score = highest valid CRPS − lowest (was: p90 − lowest under the cap).
- `test_set_get_scores`: asserts the read-back `percentile95` and adds the old-key COALESCE regression.
- Fixture keys renamed across `test_moving_average_unit` / `test_forward` / `test_miner_data_handler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)